### PR TITLE
Further improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,14 @@ dependencies {
 </dependency>
 ```
 
-## Example
+## Examples
 
-This example is used in the test suite.
+For more examples, you can consult the [tests](src/test/groovy/gg/xp/xivapi/test).
+You can also take a look at the [xivgear.app data API](https://github.com/xiv-gear-planner/xivgear-data-api)
+as an example of real-world usage. Note that both of these are written in Groovy, however, the API client itself
+is written in pure Java and does not have any Groovy dependencies. The only difference when using Groovy is that
+you should still write your interfaces in Java, as there are some subtle differences, such as how default
+methods work internally.
 
 ### Data Model
 
@@ -197,10 +202,6 @@ public interface Item extends XivApiObject {
 
 ## Examples
 
-For more examples, you can consult the [tests](src/test/groovy/gg/xp/xivapi/test).
-You can also take a look at the [xivgear.app data API](https://github.com/xiv-gear-planner/xivgear-data-api)
-as an example of real-world usage. Note that both of these are written in Groovy, however, the API client itself
-is written in pure Java and does not have any Groovy dependencies.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ public interface Item extends XivApiObject {
 }
 ```
 
+All such objects and structs extend `java.io.Serializable`, so you can directly use normal Java serialization to efficiently transfer
+or store them. However, the burden is on the library consumer to manage version compatibility. One way of doing this is to store data
+in a wrapper object, and bump the `serialVersionUID`. In addition, there is no guarantee that objects serialized by one version of the
+library will be compatible with 
+
 ### Query Single Row by ID
 
 Then, to query for a specific row, simply use getById(class, id):

--- a/src/main/java/gg/xp/xivapi/XivApiClient.java
+++ b/src/main/java/gg/xp/xivapi/XivApiClient.java
@@ -10,6 +10,7 @@ import gg.xp.xivapi.clienttypes.XivApiSettings;
 import gg.xp.xivapi.exceptions.XivApiException;
 import gg.xp.xivapi.exceptions.XivApiMappingException;
 import gg.xp.xivapi.filters.SearchFilter;
+import gg.xp.xivapi.impl.DedupeCacheImpl;
 import gg.xp.xivapi.impl.UrlResolverImpl;
 import gg.xp.xivapi.impl.XivApiContext;
 import gg.xp.xivapi.mappers.objects.ObjectFieldMapper;
@@ -210,7 +211,8 @@ public class XivApiClient implements AutoCloseable {
 
 		XivApiSchemaVersion sv = MappingUtils.makeSchemaVersion(root.get("schema").textValue());
 
-		XivApiContext context = new XivApiContext(root, settings, sv, urlResolver);
+		var cache = new DedupeCacheImpl();
+		XivApiContext context = new XivApiContext(root, settings, sv, urlResolver, cache);
 
 		return mapping.getWrappedMapper().getValue(root, context);
 	}
@@ -262,7 +264,7 @@ public class XivApiClient implements AutoCloseable {
 
 		JsonNode firstPage = sendGET(firstPageUri);
 
-		return new XivApiListPaginator<>(this, firstPage, firstPageUri, options::shouldStop, mapping.getWrappedMapper(), 100);
+		return new XivApiListPaginator<>(this, firstPage, firstPageUri, options::shouldStop, mapping.getWrappedMapper(), 100, options.getListCacheMode());
 	}
 
 	public <X extends XivApiObject> XivApiPaginator<X> getSearchIterator(Class<X> cls, SearchFilter filter) {
@@ -298,7 +300,7 @@ public class XivApiClient implements AutoCloseable {
 
 		JsonNode firstPage = sendGET(firstPageUri);
 
-		return new XivApiSearchPaginator<>(this, firstPage, firstPageUri, options::shouldStop, mapping.getWrappedMapper(), 100);
+		return new XivApiSearchPaginator<>(this, firstPage, firstPageUri, options::shouldStop, mapping.getWrappedMapper(), 100, options.getListCacheMode());
 	}
 
 	/**

--- a/src/main/java/gg/xp/xivapi/XivApiClient.java
+++ b/src/main/java/gg/xp/xivapi/XivApiClient.java
@@ -45,7 +45,7 @@ import java.util.function.Consumer;
 /**
  * The main xivapi client class.
  */
-public class XivApiClient implements AutoCloseable, XivApiUrlResolver {
+public class XivApiClient implements AutoCloseable {
 	private static final Logger log = LoggerFactory.getLogger(XivApiClient.class);
 
 	private static final ExecutorService exs = Executors.newCachedThreadPool(
@@ -321,6 +321,10 @@ public class XivApiClient implements AutoCloseable, XivApiUrlResolver {
 
 	public <X extends XivApiObject> void validateModel(Class<X> clazz) {
 		getMapping(clazz);
+	}
+
+	public XivApiUrlResolver getUrlResolver() {
+		return urlResolver;
 	}
 
 	/**

--- a/src/main/java/gg/xp/xivapi/annotations/EmptyStringNull.java
+++ b/src/main/java/gg/xp/xivapi/annotations/EmptyStringNull.java
@@ -1,0 +1,14 @@
+package gg.xp.xivapi.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that empty strings should be transformed to a null.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.METHOD})
+public @interface EmptyStringNull {
+}

--- a/src/main/java/gg/xp/xivapi/annotations/XivApiMapKeys.java
+++ b/src/main/java/gg/xp/xivapi/annotations/XivApiMapKeys.java
@@ -10,5 +10,8 @@ import java.lang.annotation.RetentionPolicy;
  */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface XivApiMapKeys {
+	/**
+	 * @return Which keys to include as a regex
+	 */
 	@RegExp String value();
 }

--- a/src/main/java/gg/xp/xivapi/collections/KeyedAlikeMap.java
+++ b/src/main/java/gg/xp/xivapi/collections/KeyedAlikeMap.java
@@ -39,7 +39,7 @@ public class KeyedAlikeMap<K, V> implements Map<K, V> {
 	private final Object[] valueMapping;
 	// Sentry value for elements which have explicitly been set to null.
 	// Unset values instead have a literal null.
-	private final Object NULL_MARKER = new Object();
+	private static final Object NULL_MARKER = new Object();
 
 	KeyedAlikeMap(Map<K, Integer> keyMapping) {
 		//noinspection AssignmentOrReturnOfFieldWithMutableType

--- a/src/main/java/gg/xp/xivapi/exceptions/XivApiDeserializationException.java
+++ b/src/main/java/gg/xp/xivapi/exceptions/XivApiDeserializationException.java
@@ -1,5 +1,8 @@
 package gg.xp.xivapi.exceptions;
 
+/**
+ * General exception for when we are trying to deserialize a response and something goes wrong with that.
+ */
 public class XivApiDeserializationException extends XivApiException {
 	public XivApiDeserializationException() {
 	}

--- a/src/main/java/gg/xp/xivapi/exceptions/XivApiException.java
+++ b/src/main/java/gg/xp/xivapi/exceptions/XivApiException.java
@@ -1,5 +1,8 @@
 package gg.xp.xivapi.exceptions;
 
+/**
+ * Top-level exception for XivApi-related errors.
+ */
 public class XivApiException extends RuntimeException {
 	public XivApiException() {
 	}

--- a/src/main/java/gg/xp/xivapi/exceptions/XivApiMappingException.java
+++ b/src/main/java/gg/xp/xivapi/exceptions/XivApiMappingException.java
@@ -1,5 +1,8 @@
 package gg.xp.xivapi.exceptions;
 
+/**
+ * Exception for when we are not able to create our tree of node mappers.
+ */
 public class XivApiMappingException extends XivApiException {
 	public XivApiMappingException() {
 	}

--- a/src/main/java/gg/xp/xivapi/exceptions/XivApiMissingNodeException.java
+++ b/src/main/java/gg/xp/xivapi/exceptions/XivApiMissingNodeException.java
@@ -6,6 +6,10 @@ import org.jetbrains.annotations.Nullable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 
+/**
+ * Specific exception for when we are trying to deserialize something and an expected node is completely missing from
+ * the response.
+ */
 public class XivApiMissingNodeException extends XivApiDeserializationException {
 	private final String messageBase;
 	private final JsonNode node;

--- a/src/main/java/gg/xp/xivapi/filters/SearchFilter.java
+++ b/src/main/java/gg/xp/xivapi/filters/SearchFilter.java
@@ -8,4 +8,8 @@ public interface SearchFilter {
 	 * @return This search filter, formatted into a string.
 	 */
 	String toFilterString();
+
+	default String toFilterStringWrapped() {
+		return toFilterString();
+	}
 }

--- a/src/main/java/gg/xp/xivapi/filters/SearchFilters.java
+++ b/src/main/java/gg/xp/xivapi/filters/SearchFilters.java
@@ -39,7 +39,14 @@ public final class SearchFilters {
 		public String toFilterString() {
 			return filters.stream()
 					.map(SearchFilter::toFilterString)
-					.map(s -> "+" + s)
+					.map(s -> {
+						// For negative filters, we must not add a +.
+						// i.e. "+Foo=GoodValue -Bar=BadValue" is correct, but "+Foo=GoodValue +-Bar=BadValue" is not.
+						if (s.startsWith("-")) {
+							return s;
+						}
+						return "+" + s;
+					})
 					.collect(Collectors.joining(" "));
 		}
 
@@ -55,7 +62,11 @@ public final class SearchFilters {
 
 		@Override
 		public String toFilterString() {
-			return "-" + filter.toFilterString();
+			String inner = filter.toFilterString();
+			if (inner.startsWith("-") || inner.startsWith("+")) {
+				return "-(" + inner + ")";
+			}
+			return "-" + inner;
 		}
 
 		@Override

--- a/src/main/java/gg/xp/xivapi/impl/DedupeCache.java
+++ b/src/main/java/gg/xp/xivapi/impl/DedupeCache.java
@@ -1,0 +1,7 @@
+package gg.xp.xivapi.impl;
+
+import java.util.function.Function;
+
+public interface DedupeCache {
+	<K, T> T computeIfAbsent(Class<T> type, K cacheKey, Function<K, T> mappingFunction);
+}

--- a/src/main/java/gg/xp/xivapi/impl/DedupeCacheImpl.java
+++ b/src/main/java/gg/xp/xivapi/impl/DedupeCacheImpl.java
@@ -1,0 +1,18 @@
+package gg.xp.xivapi.impl;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+public class DedupeCacheImpl implements DedupeCache {
+	private record CacheKey(Class<?> type, Object values) {}
+
+	private final Map<CacheKey, Object> cache = new ConcurrentHashMap<>();
+
+	@Override
+	public <K, T> T computeIfAbsent(Class<T> type, K cacheKey, Function<K, T> mappingFunction) {
+		var key = new CacheKey(type, cacheKey);
+		//noinspection unchecked
+		return (T) cache.computeIfAbsent(key, (ck) -> mappingFunction.apply((K) ck.values));
+	}
+}

--- a/src/main/java/gg/xp/xivapi/impl/NoopDedupeCache.java
+++ b/src/main/java/gg/xp/xivapi/impl/NoopDedupeCache.java
@@ -1,0 +1,11 @@
+package gg.xp.xivapi.impl;
+
+import java.util.function.Function;
+
+public class NoopDedupeCache implements DedupeCache{
+	public static final DedupeCache INSTANCE = new NoopDedupeCache();
+	@Override
+	public <K, T> T computeIfAbsent(Class<T> type, K cacheKey, Function<K, T> mappingFunction) {
+		return mappingFunction.apply(cacheKey);
+	}
+}

--- a/src/main/java/gg/xp/xivapi/impl/XivApiContext.java
+++ b/src/main/java/gg/xp/xivapi/impl/XivApiContext.java
@@ -8,5 +8,5 @@ import gg.xp.xivapi.url.XivApiUrlResolver;
 /**
  * Top-level deserialization context
  */
-public record XivApiContext(JsonNode rootNode, XivApiSettings settings, XivApiSchemaVersion schemaVersion, XivApiUrlResolver urlResolver) {
+public record XivApiContext(JsonNode rootNode, XivApiSettings settings, XivApiSchemaVersion schemaVersion, XivApiUrlResolver urlResolver, DedupeCache cache) {
 }

--- a/src/main/java/gg/xp/xivapi/mappers/BasicValueMapper.java
+++ b/src/main/java/gg/xp/xivapi/mappers/BasicValueMapper.java
@@ -2,11 +2,13 @@ package gg.xp.xivapi.mappers;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import gg.xp.xivapi.annotations.EmptyStringNull;
 import gg.xp.xivapi.exceptions.XivApiException;
 import gg.xp.xivapi.impl.XivApiContext;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Mapper for an individual value (numeric, string, boolean)
@@ -16,16 +18,25 @@ import java.util.List;
 public class BasicValueMapper<X> implements FieldMapper<X> {
 	private final Class<X> fieldType;
 	private final ObjectMapper mapper;
+	private final boolean blankNull;
 
 	public BasicValueMapper(Class<X> fieldType, Method method, ObjectMapper mapper) {
 		this.fieldType = fieldType;
 		this.mapper = mapper;
+		blankNull = method.isAnnotationPresent(EmptyStringNull.class) || method.getAnnotatedReturnType().isAnnotationPresent(EmptyStringNull.class);
+		if (blankNull && !fieldType.equals(String.class)) {
+			throw new IllegalArgumentException("Method '" + method + "' must have a non-empty String");
+		}
 	}
 
 	@Override
 	public X getValue(JsonNode current, XivApiContext context) {
 		try {
-			return mapper.convertValue(current, fieldType);
+			X out = mapper.convertValue(current, fieldType);
+			if (blankNull && "".equals(out)) {
+				return null;
+			}
+			return out;
 		}
 		catch (Throwable t) {
 			throw new XivApiException("Error deserializing value %s into %s".formatted(current, fieldType), t);

--- a/src/main/java/gg/xp/xivapi/mappers/getters/AssetUrlFieldMapper.java
+++ b/src/main/java/gg/xp/xivapi/mappers/getters/AssetUrlFieldMapper.java
@@ -6,11 +6,10 @@ import gg.xp.xivapi.annotations.XivApiAssetPath;
 import gg.xp.xivapi.impl.XivApiContext;
 import gg.xp.xivapi.mappers.FieldMapper;
 import gg.xp.xivapi.mappers.QueryFieldsBuilder;
-import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 
 import java.lang.reflect.Method;
 import java.net.URI;
-import java.util.HashMap;
+import java.net.URL;
 
 public class AssetUrlFieldMapper<X> implements FieldMapper<X> {
 
@@ -33,6 +32,38 @@ public class AssetUrlFieldMapper<X> implements FieldMapper<X> {
 		try {
 			String raw = current.textValue();
 			URI out = context.urlResolver().getAssetUri(raw, format);
+			// Possible future improvement - intern pieces of the URI
+//			if (returnType.equals(URI.class)) {
+//				String scheme = out.getScheme();
+//				String userInfo = out.getUserInfo();
+//				String host = out.getHost();
+//				String query = out.getQuery();
+//
+//				if (scheme != null) {
+//					scheme = scheme.intern();
+//				}
+//				if (userInfo != null) {
+//					userInfo = userInfo.intern();
+//				}
+//				if (host != null) {
+//					host = host.intern();
+//				}
+//				if (query != null) {
+//					query = query.intern();
+//				}
+//
+//				// Rebuild the URI with interned components
+//				URI newOut = new URI(
+//						scheme,
+//						userInfo,
+//						host,
+//						out.getPort(),
+//						out.getPath(),
+//						query,
+//						out.getFragment()
+//				);
+//				return (X) newOut;
+//			}
 			return mapper.convertValue(out, returnType);
 		}
 		catch (Throwable t) {

--- a/src/main/java/gg/xp/xivapi/mappers/getters/MetaFieldMapper.java
+++ b/src/main/java/gg/xp/xivapi/mappers/getters/MetaFieldMapper.java
@@ -2,6 +2,9 @@ package gg.xp.xivapi.mappers.getters;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import gg.xp.xivapi.exceptions.XivApiDeserializationException;
+import gg.xp.xivapi.exceptions.XivApiMappingException;
+import gg.xp.xivapi.exceptions.XivApiMissingNodeException;
 import gg.xp.xivapi.impl.XivApiContext;
 import gg.xp.xivapi.mappers.FieldMapper;
 import gg.xp.xivapi.mappers.QueryFieldsBuilder;
@@ -12,23 +15,27 @@ import java.util.List;
 public class MetaFieldMapper<X> implements FieldMapper<X> {
 	private final String metaFieldName;
 	private final Class<X> fieldType;
+	private final Method method;
 	private final ObjectMapper mapper;
 
 	public MetaFieldMapper(String metaFieldName, Class<X> fieldType, Method method, ObjectMapper mapper) {
 		this.metaFieldName = metaFieldName;
 		this.fieldType = fieldType;
+		this.method = method;
 		this.mapper = mapper;
 	}
 
 	@Override
 	public X getValue(JsonNode current, XivApiContext context) {
+		if (current == null) {
+			throw new XivApiMissingNodeException("'current' is null", null, fieldType, method);
+		}
 		try {
-			// TODO: clean up error handling when 'current' is null
 			var fieldNode = current.get(metaFieldName);
 			return mapper.convertValue(fieldNode, fieldType);
 		}
 		catch (Throwable t) {
-			throw new RuntimeException("Error deserializing %s".formatted(metaFieldName), t);
+			throw new XivApiDeserializationException("Error deserializing %s".formatted(metaFieldName), t);
 		}
 	}
 

--- a/src/main/java/gg/xp/xivapi/mappers/objects/ArrayFieldMapper.java
+++ b/src/main/java/gg/xp/xivapi/mappers/objects/ArrayFieldMapper.java
@@ -39,14 +39,14 @@ public class ArrayFieldMapper<X> implements FieldMapper<X[]> {
 			throw new IllegalArgumentException("Type must be an array, not %s".formatted(cls));
 		}
 		// TODO: this doesn't support generic types
-		Class<?> listTypeAsCls = cls.componentType();
-		this.componentType = (Class<X>) listTypeAsCls;
+		Class<?> elementTypeAsCls = cls.componentType();
+		this.componentType = (Class<X>) elementTypeAsCls;
 		omitZero = method.isAnnotationPresent(OmitZeroes.class);
-		if (omitZero && !XivApiObject.class.isAssignableFrom(listTypeAsCls)) {
+		if (omitZero && !XivApiObject.class.isAssignableFrom(elementTypeAsCls)) {
 			throw new IllegalArgumentException("@OmitZeroes only makes sense when dealing with a sheet object type");
 		}
 		//noinspection unchecked
-		this.innerMapper = new AutoValueMapper<>((Class<X>) listTypeAsCls, method, listTypeAsCls, mapper);
+		this.innerMapper = new AutoValueMapper<>((Class<X>) elementTypeAsCls, method, elementTypeAsCls, mapper);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/gg/xp/xivapi/mappers/objects/LangValueFieldMapper.java
+++ b/src/main/java/gg/xp/xivapi/mappers/objects/LangValueFieldMapper.java
@@ -63,7 +63,7 @@ public class LangValueFieldMapper<X> implements FieldMapper<XivApiLangValue<X>> 
 		fieldsNode.fields().forEachRemaining(entry -> {
 			Matcher matcher = fieldMatcher.matcher(entry.getKey());
 			if (matcher.matches()) {
-				String lang = matcher.group(1);
+				String lang = matcher.group(1).intern();
 				X value = innerMapper.getValue(entry.getValue(), context);
 				out.put(lang, value);
 			}

--- a/src/main/java/gg/xp/xivapi/mappers/objects/ObjectFieldMapper.java
+++ b/src/main/java/gg/xp/xivapi/mappers/objects/ObjectFieldMapper.java
@@ -184,8 +184,12 @@ public class ObjectFieldMapper<X> implements FieldMapper<X> {
 
 		boolean strict = context.settings().isStrict();
 
-		//noinspection unchecked
-		return (X) Proxy.newProxyInstance(this.getClass().getClassLoader(), new Class[]{objectType}, new ObjectInvocationHandler(methodValueMap, strict));
+		// It is not necessary to use the `strict` flag as part of the cache key, as both the strict flag and the cache
+		// itself are both scoped to the context object.
+		return context.cache().computeIfAbsent(objectType, methodValueMap, map -> {
+			//noinspection unchecked
+			return (X) Proxy.newProxyInstance(this.getClass().getClassLoader(), new Class[]{objectType}, new ObjectInvocationHandler(map, strict));
+		});
 
 	}
 

--- a/src/main/java/gg/xp/xivapi/mappers/objects/ObjectFieldMapper.java
+++ b/src/main/java/gg/xp/xivapi/mappers/objects/ObjectFieldMapper.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.net.URI;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -167,6 +168,8 @@ public class ObjectFieldMapper<X> implements FieldMapper<X> {
 			methodValueMap.put(pkMethod, primaryKey);
 			methodValueMap.put(ridMethod, rowId);
 			methodValueMap.put(svMethod, context.schemaVersion());
+			// TODO: this would work better as some kind of lazy value, as it is not ideal to have to intern every
+			// single instance of these to save memory.
 			methodValueMap.put(tsMethod, "%s(%s)".formatted(objectType.getSimpleName(), rowId));
 			// Go through the method -> field map, deserialize each field into its respective type, and then
 			// assemble a method -> value map.

--- a/src/main/java/gg/xp/xivapi/mappers/objects/ObjectInvocationHandler.java
+++ b/src/main/java/gg/xp/xivapi/mappers/objects/ObjectInvocationHandler.java
@@ -74,12 +74,12 @@ public class ObjectInvocationHandler implements InvocationHandler, Serializable 
 						return true;
 					}
 					else if (that instanceof XivApiObject other) {
-						var otherValueMap = other.getMethodValueMap();
-						return MappingUtils.methodMapEquals(methodValueMap, otherValueMap);
+						if (Arrays.equals(proxy.getClass().getGenericInterfaces(), other.getClass().getGenericInterfaces())) {
+							var otherValueMap = other.getMethodValueMap();
+							return MappingUtils.methodMapEquals(methodValueMap, otherValueMap);
+						}
 					}
-					else {
-						return false;
-					}
+					return false;
 				}
 			}
 

--- a/src/main/java/gg/xp/xivapi/mappers/objects/ObjectInvocationHandler.java
+++ b/src/main/java/gg/xp/xivapi/mappers/objects/ObjectInvocationHandler.java
@@ -144,7 +144,9 @@ public class ObjectInvocationHandler implements InvocationHandler, Serializable 
 		}
 	}
 
-	public static class MethodMetadata implements Serializable {
+	// TODO: this should be de-duplicated with the equivalent in StructInvocationHandler, but that would break
+	// serialization compatibility, so hold off for now.
+	public static final class MethodMetadata implements Serializable {
 		@Serial
 		private static final long serialVersionUID = 1L;
 
@@ -152,10 +154,13 @@ public class ObjectInvocationHandler implements InvocationHandler, Serializable 
 		private final String[] parameterTypeNames;
 		private final String interfaceClassName;
 
-		public MethodMetadata(String methodName, String[] parameterTypeNames, String interfaceClassName) {
-			this.methodName = methodName;
+		private MethodMetadata(String methodName, String[] parameterTypeNames, String interfaceClassName) {
+			this.methodName = methodName.intern();
+			for (int i = 0; i < parameterTypeNames.length; i++) {
+				parameterTypeNames[i] = parameterTypeNames[i].intern();
+			}
 			this.parameterTypeNames = parameterTypeNames;
-			this.interfaceClassName = interfaceClassName;
+			this.interfaceClassName = interfaceClassName.intern();
 		}
 
 		public static MethodMetadata fromMethod(Method method) {

--- a/src/main/java/gg/xp/xivapi/mappers/objects/ObjectInvocationHandler.java
+++ b/src/main/java/gg/xp/xivapi/mappers/objects/ObjectInvocationHandler.java
@@ -1,5 +1,6 @@
 package gg.xp.xivapi.mappers.objects;
 
+import gg.xp.xivapi.annotations.EmptyStringNull;
 import gg.xp.xivapi.annotations.NullIfZero;
 import gg.xp.xivapi.clienttypes.XivApiBase;
 import gg.xp.xivapi.clienttypes.XivApiObject;
@@ -98,7 +99,10 @@ public class ObjectInvocationHandler implements InvocationHandler, Serializable 
 			}
 			else {
 				if (!(method.isAnnotationPresent(NullIfZero.class)
-				      || returnType.isAnnotationPresent(NullIfZero.class))) {
+				      || returnType.isAnnotationPresent(NullIfZero.class)
+				      || (returnType.equals(String.class)
+				          && (method.isAnnotationPresent(EmptyStringNull.class)
+				              || method.getAnnotatedReturnType().isAnnotationPresent(EmptyStringNull.class))))) {
 					if (strict) {
 						throw new XivApiDeserializationException("Null object field! %s".formatted(method));
 					}

--- a/src/main/java/gg/xp/xivapi/mappers/objects/StructFieldMapper.java
+++ b/src/main/java/gg/xp/xivapi/mappers/objects/StructFieldMapper.java
@@ -70,7 +70,7 @@ public class StructFieldMapper<X> implements FieldMapper<X> {
 
 		final Map<Method, Object> methodValueMap = kaMapFactory.create();
 		methodValueMap.put(svMethod, context.schemaVersion());
-		methodValueMap.put(tsMethod, "%s(StructProxy)".formatted(objectType.getSimpleName()));
+		methodValueMap.put(tsMethod, "%s(StructProxy)".formatted(objectType.getSimpleName()).intern());
 		methodFieldMap.forEach((method, fieldMapper) -> {
 			Object value = fieldMapper.getValue(current, context);
 			methodValueMap.put(method, value);

--- a/src/main/java/gg/xp/xivapi/mappers/objects/StructInvocationHandler.java
+++ b/src/main/java/gg/xp/xivapi/mappers/objects/StructInvocationHandler.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -144,17 +145,21 @@ public class StructInvocationHandler implements InvocationHandler, Serializable 
 		}
 	}
 
-	public static class MethodMetadata implements Serializable {
+	public static final class MethodMetadata implements Serializable {
+		@Serial
 		private static final long serialVersionUID = 1L;
 
 		private final String methodName;
 		private final String[] parameterTypeNames;
 		private final String interfaceClassName;
 
-		public MethodMetadata(String methodName, String[] parameterTypeNames, String interfaceClassName) {
-			this.methodName = methodName;
+		private MethodMetadata(String methodName, String[] parameterTypeNames, String interfaceClassName) {
+			this.methodName = methodName.intern();
+			for (int i = 0; i < parameterTypeNames.length; i++) {
+				parameterTypeNames[i] = parameterTypeNames[i].intern();
+			}
 			this.parameterTypeNames = parameterTypeNames;
-			this.interfaceClassName = interfaceClassName;
+			this.interfaceClassName = interfaceClassName.intern();
 		}
 
 		public static MethodMetadata fromMethod(Method method) {

--- a/src/main/java/gg/xp/xivapi/mappers/util/MappingUtils.java
+++ b/src/main/java/gg/xp/xivapi/mappers/util/MappingUtils.java
@@ -141,7 +141,6 @@ public final class MappingUtils {
 		return out;
 	}
 
-	// TODO: unit tests
 	public static boolean unknownValueEquals(Object left, Object right) {
 		if (left == null && right == null) {
 			return true;

--- a/src/main/java/gg/xp/xivapi/mappers/util/MappingUtils.java
+++ b/src/main/java/gg/xp/xivapi/mappers/util/MappingUtils.java
@@ -48,7 +48,7 @@ public final class MappingUtils {
 			fieldName = method.getName().substring(2);
 		}
 		else {
-			throw new RuntimeException("I don't know how to map " + method.getName());
+			throw new IllegalArgumentException("I don't know how to map field name '" + method.getName() + "' to a field");
 		}
 		return fieldName;
 	}

--- a/src/main/java/gg/xp/xivapi/pagination/ListCacheMode.java
+++ b/src/main/java/gg/xp/xivapi/pagination/ListCacheMode.java
@@ -1,8 +1,27 @@
 package gg.xp.xivapi.pagination;
 
+/**
+ * Controls how inner object deduplication works in the context of lists and searching.
+ * e.g. if two Items have the same ClassJobCategory, then instead of keeping two objects with identical contents
+ * in memory, both Items can simply point to the same ClassJobCategory instance. For single-object requests, the "scope"
+ * of deduplication is that single request. For lists/searches, the behavior can be configured, as if it is not
+ * expected that there will be very many duplicates, the caching may not be helpful.
+ */
 public enum ListCacheMode {
+	/**
+	 * No caching at all.
+	 */
 	None,
+	/**
+	 * Cache context per item - same as if the items were retrieved individually.
+	 */
 	PerItem,
+	/**
+	 * Cache context per page of items.
+	 */
 	PerPage,
+	/**
+	 * One cache context for the whole list/search.
+	 */
 	WholeQuery
 }

--- a/src/main/java/gg/xp/xivapi/pagination/ListCacheMode.java
+++ b/src/main/java/gg/xp/xivapi/pagination/ListCacheMode.java
@@ -1,0 +1,8 @@
+package gg.xp.xivapi.pagination;
+
+public enum ListCacheMode {
+	None,
+	PerItem,
+	PerPage,
+	WholeQuery
+}

--- a/src/main/java/gg/xp/xivapi/pagination/ListOptions.java
+++ b/src/main/java/gg/xp/xivapi/pagination/ListOptions.java
@@ -2,14 +2,20 @@ package gg.xp.xivapi.pagination;
 
 import java.util.function.BiPredicate;
 
-@SuppressWarnings("ClassCanBeRecord") // Future expansion
 public class ListOptions<X> {
 	private final int perPage;
 	private final BiPredicate<Integer, X> stopCondition;
+	private final ListCacheMode listCacheMode;
 
+	@Deprecated // Use builder
 	public ListOptions(int perPage, BiPredicate<Integer, X> stopCondition) {
+		this(perPage, stopCondition, ListCacheMode.WholeQuery);
+	}
+
+	private ListOptions(int perPage, BiPredicate<Integer, X> stopCondition, ListCacheMode listCacheMode) {
 		this.perPage = perPage;
 		this.stopCondition = stopCondition;
+		this.listCacheMode = listCacheMode;
 	}
 
 	public int getPerPage() {
@@ -24,6 +30,10 @@ public class ListOptions<X> {
 		return stopCondition.test(page, item);
 	}
 
+	public ListCacheMode getListCacheMode() {
+		return listCacheMode;
+	}
+
 	public static <X> ListOptionsBuilder<X> newBuilder() {
 		return new ListOptionsBuilder<>();
 	}
@@ -31,6 +41,7 @@ public class ListOptions<X> {
 	public static class ListOptionsBuilder<X> {
 		private int perPage = 100;
 		private BiPredicate<Integer, X> stopCondition = (index, value) -> false;
+		private ListCacheMode listCacheMode = ListCacheMode.WholeQuery;
 
 		public ListOptionsBuilder<X> perPage(int perPage) {
 			this.perPage = perPage;
@@ -42,8 +53,13 @@ public class ListOptions<X> {
 			return this;
 		}
 
+		public ListOptionsBuilder<X> listCacheMode(ListCacheMode listCacheMode) {
+			this.listCacheMode = listCacheMode;
+			return this;
+		}
+
 		public ListOptions<X> build() {
-			return new ListOptions<>(perPage, stopCondition);
+			return new ListOptions<>(perPage, stopCondition, listCacheMode);
 		}
 	}
 }

--- a/src/main/java/gg/xp/xivapi/pagination/XivApiListPaginator.java
+++ b/src/main/java/gg/xp/xivapi/pagination/XivApiListPaginator.java
@@ -23,8 +23,8 @@ import java.util.function.BiPredicate;
  */
 public final class XivApiListPaginator<X extends XivApiObject> extends XivApiPaginator<X> {
 
-	public XivApiListPaginator(XivApiClient client, JsonNode firstResponse, URI originalUri, BiPredicate<Integer, X> stopCondition, FieldMapper<X> mapper, int perPageItemCount) {
-		super(client, originalUri, stopCondition, mapper, perPageItemCount, firstResponse);
+	public XivApiListPaginator(XivApiClient client, JsonNode firstResponse, URI originalUri, BiPredicate<Integer, X> stopCondition, FieldMapper<X> mapper, int perPageItemCount, ListCacheMode cacheMode) {
+		super(client, originalUri, stopCondition, mapper, perPageItemCount, firstResponse, cacheMode);
 	}
 
 	@Override

--- a/src/main/java/gg/xp/xivapi/pagination/XivApiPaginator.java
+++ b/src/main/java/gg/xp/xivapi/pagination/XivApiPaginator.java
@@ -47,7 +47,6 @@ public abstract sealed class XivApiPaginator<X extends XivApiObject> implements 
 	protected abstract URI getNextPageUri();
 
 	private void nextPage() {
-		// TODO: getLast requires 21+ - do we want to support older Java versions?
 		globalBaseIndex += currentPage.size();
 		URI newURI = getNextPageUri();
 
@@ -102,7 +101,7 @@ public abstract sealed class XivApiPaginator<X extends XivApiObject> implements 
 			Iterable<JsonNode> iter = rows::elements;
 			values = StreamSupport.stream(iter.spliterator(), false)
 					.map(node -> {
-						var context = new XivApiContext(node, client.getSettings(), sv, client);
+						var context = new XivApiContext(node, client.getSettings(), sv, client.getUrlResolver());
 						return mapper.getValue(node, context);
 					})
 					.toList();

--- a/src/main/java/gg/xp/xivapi/pagination/XivApiPaginator.java
+++ b/src/main/java/gg/xp/xivapi/pagination/XivApiPaginator.java
@@ -5,6 +5,9 @@ import gg.xp.xivapi.XivApiClient;
 import gg.xp.xivapi.clienttypes.XivApiObject;
 import gg.xp.xivapi.clienttypes.XivApiSchemaVersion;
 import gg.xp.xivapi.exceptions.XivApiDeserializationException;
+import gg.xp.xivapi.impl.DedupeCache;
+import gg.xp.xivapi.impl.DedupeCacheImpl;
+import gg.xp.xivapi.impl.NoopDedupeCache;
 import gg.xp.xivapi.impl.XivApiContext;
 import gg.xp.xivapi.mappers.FieldMapper;
 import gg.xp.xivapi.mappers.util.MappingUtils;
@@ -31,16 +34,26 @@ public abstract sealed class XivApiPaginator<X extends XivApiObject> implements 
 	private final BiPredicate<Integer, X> stopCondition;
 	private final FieldMapper<X> mapper;
 	protected final int perPageItemCount;
+	private final ListCacheMode cacheMode;
+	private final DedupeCache cache;
 	protected XivApiPage currentPage;
 	private int globalBaseIndex;
 	private boolean hasHitStopCondition;
 
-	XivApiPaginator(XivApiClient client, URI originalUri, BiPredicate<Integer, X> stopCondition, FieldMapper<X> mapper, int perPageItemCount, JsonNode firstResponse) {
+	XivApiPaginator(XivApiClient client, URI originalUri, BiPredicate<Integer, X> stopCondition, FieldMapper<X> mapper, int perPageItemCount, JsonNode firstResponse, ListCacheMode cacheMode) {
 		this.client = client;
 		this.originalUri = originalUri;
 		this.stopCondition = stopCondition;
 		this.mapper = mapper;
 		this.perPageItemCount = perPageItemCount;
+		this.cacheMode = cacheMode;
+		switch (cacheMode) {
+			case None -> cache = NoopDedupeCache.INSTANCE;
+			case PerItem, PerPage -> cache = null;
+			case WholeQuery -> cache = new DedupeCacheImpl();
+			default -> throw new IllegalArgumentException("Unknown cache mode " + cacheMode);
+		}
+		// Must be called last as it reads instance fields!
 		currentPage = new XivApiPage(firstResponse);
 	}
 
@@ -99,9 +112,11 @@ public abstract sealed class XivApiPaginator<X extends XivApiObject> implements 
 			}
 			XivApiSchemaVersion sv = MappingUtils.makeSchemaVersion(root.get("schema").textValue());
 			Iterable<JsonNode> iter = rows::elements;
+			DedupeCache pageCache = cache == null && cacheMode == ListCacheMode.PerPage ? new DedupeCacheImpl() : cache;
 			values = StreamSupport.stream(iter.spliterator(), false)
 					.map(node -> {
-						var context = new XivApiContext(node, client.getSettings(), sv, client.getUrlResolver());
+						DedupeCache itemCache = pageCache == null && cacheMode == ListCacheMode.PerItem ? new DedupeCacheImpl() : cache;
+						var context = new XivApiContext(node, client.getSettings(), sv, client.getUrlResolver(), itemCache);
 						return mapper.getValue(node, context);
 					})
 					.toList();

--- a/src/main/java/gg/xp/xivapi/pagination/XivApiSearchPaginator.java
+++ b/src/main/java/gg/xp/xivapi/pagination/XivApiSearchPaginator.java
@@ -23,8 +23,8 @@ import java.util.function.BiPredicate;
  */
 public final class XivApiSearchPaginator<X extends XivApiObject> extends XivApiPaginator<X> {
 
-	public XivApiSearchPaginator(XivApiClient client, JsonNode firstResponse, URI originalUri, BiPredicate<Integer, X> stopCondition, FieldMapper<X> mapper, int perPageItemCount) {
-		super(client, originalUri, stopCondition, mapper, perPageItemCount, firstResponse);
+	public XivApiSearchPaginator(XivApiClient client, JsonNode firstResponse, URI originalUri, BiPredicate<Integer, X> stopCondition, FieldMapper<X> mapper, int perPageItemCount, ListCacheMode cacheMode) {
+		super(client, originalUri, stopCondition, mapper, perPageItemCount, firstResponse, cacheMode);
 	}
 
 	@Override

--- a/src/test/groovy/gg/xp/xivapi/test/basictest/ClassJobCategory.java
+++ b/src/test/groovy/gg/xp/xivapi/test/basictest/ClassJobCategory.java
@@ -7,6 +7,17 @@ import gg.xp.xivapi.clienttypes.XivApiObject;
 
 import java.util.Map;
 
+
+/*
+TODO: this ends up taking an unexpectedly large amount of memory.
+This is a good use case for some kind of re-usable element caching.
+For example, if two items have the same primary key on their ClassJobCategory,
+and the two values are equal (including schema version and all), then they
+should be replaced with the same object internally.
+We would need to ensure that there is nothing that would affect the representation
+of the object that lives out of the object itself. I don't think there is, given that
+ObjectFieldMapper only takes the target class and ObjectMapper as its arguments.
+*/
 @XivApiSheet("ClassJobCategory")
 public interface ClassJobCategory extends XivApiObject {
 	String getName();

--- a/src/test/groovy/gg/xp/xivapi/test/basictest/ClassJobCategory.java
+++ b/src/test/groovy/gg/xp/xivapi/test/basictest/ClassJobCategory.java
@@ -8,16 +8,6 @@ import gg.xp.xivapi.clienttypes.XivApiObject;
 import java.util.Map;
 
 
-/*
-TODO: this ends up taking an unexpectedly large amount of memory.
-This is a good use case for some kind of re-usable element caching.
-For example, if two items have the same primary key on their ClassJobCategory,
-and the two values are equal (including schema version and all), then they
-should be replaced with the same object internally.
-We would need to ensure that there is nothing that would affect the representation
-of the object that lives out of the object itself. I don't think there is, given that
-ObjectFieldMapper only takes the target class and ObjectMapper as its arguments.
-*/
 @XivApiSheet("ClassJobCategory")
 public interface ClassJobCategory extends XivApiObject {
 	String getName();

--- a/src/test/groovy/gg/xp/xivapi/test/basictest/ClosingTest.groovy
+++ b/src/test/groovy/gg/xp/xivapi/test/basictest/ClosingTest.groovy
@@ -1,0 +1,35 @@
+package gg.xp.xivapi.test.basictest
+
+import gg.xp.xivapi.XivApiClient
+import gg.xp.xivapi.clienttypes.XivApiSettings
+import groovy.transform.CompileDynamic
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+// Allows access to private rootMappingCache field
+@CompileDynamic
+class ClosingTest {
+	private static final String schemaVersion = "exdschema@5f292f39f3deab2c43bee62b202b54ebf51e15b7-2024.08.02.0000.0000"
+
+	@Test
+	void closeTest() {
+		var client = new XivApiClient({ XivApiSettings.Builder it ->
+			it.schemaVersion = schemaVersion
+			it.gameVersion = "7.05"
+		})
+		def item = client.getById(Item, 44096)
+		Assertions.assertEquals 1, client.rootMappingCache.size()
+		client.close()
+		Assertions.assertEquals 0, client.rootMappingCache.size()
+	}
+
+	@Test
+	void testAutoClose() {
+		try (var client = new XivApiClient({ XivApiSettings.Builder it ->
+			it.schemaVersion = schemaVersion
+			it.gameVersion = "7.05"
+		})) {
+			def item = client.getById(Item, 44096)
+		}
+	}
+}

--- a/src/test/groovy/gg/xp/xivapi/test/basictest/ContentFinderCondition.java
+++ b/src/test/groovy/gg/xp/xivapi/test/basictest/ContentFinderCondition.java
@@ -1,0 +1,13 @@
+package gg.xp.xivapi.test.basictest;
+
+import gg.xp.xivapi.annotations.EmptyStringNull;
+import gg.xp.xivapi.annotations.XivApiField;
+import gg.xp.xivapi.clienttypes.XivApiObject;
+
+public interface ContentFinderCondition extends XivApiObject {
+	@EmptyStringNull
+	@XivApiField("Name")
+	String getName();
+	@XivApiField("Name")
+	String getNameNotNull();
+}

--- a/src/test/groovy/gg/xp/xivapi/test/basictest/EmptyStringNullTest.groovy
+++ b/src/test/groovy/gg/xp/xivapi/test/basictest/EmptyStringNullTest.groovy
@@ -1,0 +1,21 @@
+package gg.xp.xivapi.test.basictest
+
+import gg.xp.xivapi.XivApiClient
+import groovy.transform.CompileStatic
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@CompileStatic
+class EmptyStringNullTest {
+	@Test
+	void test() {
+		var client = new XivApiClient()
+		// Limsa - not a duty
+		var limsa = client.getById(TerritoryType, 128)
+		Assertions.assertNotNull(limsa.contentFinderConditionNonNull)
+		Assertions.assertNull(limsa.contentFinderConditionNonNull.name)
+		Assertions.assertEquals("", limsa.contentFinderConditionNonNull.nameNotNull)
+		Assertions.assertEquals(0, limsa.contentFinderConditionNonNull.rowId)
+		Assertions.assertNull(limsa.contentFinderConditionNullable)
+	}
+}

--- a/src/test/groovy/gg/xp/xivapi/test/basictest/Icon.java
+++ b/src/test/groovy/gg/xp/xivapi/test/basictest/Icon.java
@@ -26,8 +26,6 @@ public interface Icon extends XivApiStruct {
 	@XivApiAssetPath(format = "jpg")
 	URI getAssetPathHDasURI();
 
-
-	// TODO: this should move, otherwise it won't be possible to change the base url
 	default URI getPngIconUrl() {
 		try {
 			return new URI("https://beta.xivapi.com/api/1/asset/" + getPath() + "?format=png");

--- a/src/test/groovy/gg/xp/xivapi/test/basictest/Item.java
+++ b/src/test/groovy/gg/xp/xivapi/test/basictest/Item.java
@@ -13,8 +13,6 @@ import java.util.List;
 // Indicate what sheet should be queried
 @XivApiSheet("Item")
 public interface Item extends XivApiObject, HasIcon {
-	// TODO: arrays
-	// TODO: schema version
 
 	// ID will always be auto-filled, but this is declared on XivApiObject so no need to do it here
 //	int getId()

--- a/src/test/groovy/gg/xp/xivapi/test/basictest/TerritoryType.java
+++ b/src/test/groovy/gg/xp/xivapi/test/basictest/TerritoryType.java
@@ -1,0 +1,16 @@
+package gg.xp.xivapi.test.basictest;
+
+import gg.xp.xivapi.annotations.NullIfZero;
+import gg.xp.xivapi.annotations.XivApiField;
+import gg.xp.xivapi.clienttypes.XivApiObject;
+
+public interface TerritoryType extends XivApiObject {
+	@NullIfZero
+	@XivApiField("ContentFinderCondition")
+	ContentFinderCondition getContentFinderConditionNullable();
+	@XivApiField("ContentFinderCondition")
+	ContentFinderCondition getContentFinderConditionNonNull();
+
+	PlaceName getPlaceName();
+
+}

--- a/src/test/groovy/gg/xp/xivapi/test/comparison/ComparisonTest.groovy
+++ b/src/test/groovy/gg/xp/xivapi/test/comparison/ComparisonTest.groovy
@@ -1,0 +1,24 @@
+package gg.xp.xivapi.test.comparison
+
+import gg.xp.xivapi.XivApiClient
+import gg.xp.xivapi.clienttypes.XivApiSettings
+import gg.xp.xivapi.test.comparison.bar.Item
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+// Test for a particular corner case.
+// Because equality is based only on whether the method->value map is equal,
+// two objects might be considered equal even if they are from different sheets.
+class ComparisonTest {
+	@Test
+	void comparisonCornerCaseTest() {
+		var client = new XivApiClient({ XivApiSettings.Builder it ->
+			it.schemaVersion = "exdschema@5f292f39f3deab2c43bee62b202b54ebf51e15b7-2024.08.02.0000.0000"
+			it.gameVersion = "7.05"
+		})
+		var action = client.getById(Item, 5)
+		var item = client.getById(gg.xp.xivapi.test.comparison.foo.Item, 5)
+		Assertions.assertNotEquals action, item
+
+	}
+}

--- a/src/test/groovy/gg/xp/xivapi/test/comparison/bar/Item.java
+++ b/src/test/groovy/gg/xp/xivapi/test/comparison/bar/Item.java
@@ -1,0 +1,8 @@
+package gg.xp.xivapi.test.comparison.bar;
+
+import gg.xp.xivapi.annotations.XivApiSheet;
+import gg.xp.xivapi.clienttypes.XivApiObject;
+
+@XivApiSheet("Action")
+public interface Item extends XivApiObject {
+}

--- a/src/test/groovy/gg/xp/xivapi/test/comparison/foo/Item.java
+++ b/src/test/groovy/gg/xp/xivapi/test/comparison/foo/Item.java
@@ -1,0 +1,6 @@
+package gg.xp.xivapi.test.comparison.foo;
+
+import gg.xp.xivapi.clienttypes.XivApiObject;
+
+public interface Item extends XivApiObject {
+}

--- a/src/test/groovy/gg/xp/xivapi/test/dedup/DedupTest.groovy
+++ b/src/test/groovy/gg/xp/xivapi/test/dedup/DedupTest.groovy
@@ -1,0 +1,49 @@
+package gg.xp.xivapi.test.dedup
+
+import gg.xp.xivapi.XivApiClient
+import gg.xp.xivapi.clienttypes.XivApiSettings
+import gg.xp.xivapi.filters.SearchFilters
+import gg.xp.xivapi.pagination.ListCacheMode
+import gg.xp.xivapi.pagination.ListOptions
+import gg.xp.xivapi.test.basictest.Item
+import groovy.transform.CompileStatic
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@CompileStatic
+class DedupTest {
+	@Test
+	void testDedup() {
+		var client = new XivApiClient({ XivApiSettings.Builder it ->
+			it.schemaVersion = "exdschema@5f292f39f3deab2c43bee62b202b54ebf51e15b7-2024.08.02.0000.0000"
+			it.gameVersion = "7.05"
+		})
+		List<Item> items = client.getSearchIterator(Item, SearchFilters.eq("ClassJobCategory", 181)).toList()
+		// Two sage weapons
+		var item1 = items.find { it.rowId == 42587 }
+		var item2 = items.find { it.rowId == 42791 }
+		// Since they are both for Sage, their classJobCategory should be equal
+		Assertions.assertEquals item1.classJobCategory, item2.classJobCategory
+		// The purpose of dedup is to replace them with the same underlying object
+		Assertions.assertSame item1.classJobCategory, item2.classJobCategory
+	}
+
+	@Test
+	void testDedupDisabled() {
+		var client = new XivApiClient({ XivApiSettings.Builder it ->
+			it.schemaVersion = "exdschema@5f292f39f3deab2c43bee62b202b54ebf51e15b7-2024.08.02.0000.0000"
+			it.gameVersion = "7.05"
+		})
+		List<Item> items = client.getSearchIterator(Item, SearchFilters.eq("ClassJobCategory", 181), ListOptions.newBuilder().with {
+			listCacheMode(ListCacheMode.None)
+			build()
+		}).toList()
+		// Two sage weapons
+		var item1 = items.find { it.rowId == 42587 }
+		var item2 = items.find { it.rowId == 42791 }
+		// Since they are both for Sage, their classJobCategory should be equal
+		Assertions.assertEquals item1.classJobCategory, item2.classJobCategory
+		// Dedup disabled, so should not be equal
+		Assertions.assertNotSame item1.classJobCategory, item2.classJobCategory
+	}
+}

--- a/src/test/groovy/gg/xp/xivapi/test/search/SearchFilterTests.groovy
+++ b/src/test/groovy/gg/xp/xivapi/test/search/SearchFilterTests.groovy
@@ -1,0 +1,119 @@
+package gg.xp.xivapi.test.search
+
+
+import org.junit.jupiter.api.Test
+
+import static gg.xp.xivapi.filters.SearchFilters.*
+import static org.junit.jupiter.api.Assertions.assertEquals
+
+class SearchFilterTests {
+	@Test
+	void testBasicFilter() {
+		var filter = of('foo')
+		assertEquals 'foo', filter.toFilterString()
+	}
+
+	@Test
+	void testEqFilterNumber() {
+		var filter = eq('Foo', 5)
+		assertEquals 'Foo=5', filter.toFilterString()
+	}
+
+	@Test
+	void testEqFilterBool() {
+		var filter = eq('Foo', false)
+		assertEquals 'Foo=false', filter.toFilterString()
+	}
+
+	@Test
+	void testEqFilterString() {
+		var filter = eq('Foo', 'Stuff')
+		assertEquals 'Foo=\"Stuff\"', filter.toFilterString()
+	}
+
+	@Test
+	void testGt() {
+		var filter = gt('Foo', 2.5)
+		assertEquals 'Foo>2.5', filter.toFilterString()
+	}
+
+	@Test
+	void testGte() {
+		var filter = gte('Foo', 2.5)
+		assertEquals 'Foo>=2.5', filter.toFilterString()
+	}
+
+	@Test
+	void testLt() {
+		var filter = lt('Foo', 2.5)
+		assertEquals 'Foo<2.5', filter.toFilterString()
+	}
+
+	@Test
+	void testLte() {
+		var filter = lte('Foo', 2.5)
+		assertEquals 'Foo<=2.5', filter.toFilterString()
+	}
+
+	@Test
+	void testNot() {
+		var filter = not(eq('Foo', 5))
+		assertEquals '-Foo=5', filter.toFilterString()
+	}
+
+	@Test
+	void testAnd() {
+		var filter = and(eq('Foo', 5), not(eq('Bar', 'Baz')))
+		assertEquals '+Foo=5 -Bar="Baz"', filter.toFilterString()
+	}
+
+	@Test
+	void testOr() {
+		// TODO add docs about or + not
+		var filter = or(eq('Foo', 5), not(eq('Bar', 'Baz')))
+		assertEquals 'Foo=5 (-Bar="Baz")', filter.toFilterString()
+	}
+
+	@Test
+	void testAndOuterNot() {
+		var filter = not(and(eq('Foo', 5), not(eq('Bar', 'Baz'))))
+		assertEquals '-(+Foo=5 -(Bar="Baz"))', filter.toFilterString()
+	}
+
+	@Test
+	void testAndOr() {
+		var filter = and(or(eq('Foo', 5), not(eq('Bar', 'Baz'))), gt('Stuff', 2.5))
+		assertEquals '+(Foo=5 (-Bar="Baz")) +Stuff>2.5', filter.toFilterString()
+	}
+
+	@Test
+	void testIsTrue() {
+		var filter = isTrue('Foo')
+		assertEquals 'Foo=true', filter.toFilterString()
+	}
+
+	@Test
+	void testIsFalse() {
+		var filter = isFalse('Foo')
+		assertEquals 'Foo=false', filter.toFilterString()
+	}
+
+	@Test
+	void testStrPart() {
+		var filter = strPart('Foo', 'PartialText')
+		assertEquals 'Foo~"PartialText"', filter.toFilterString()
+	}
+
+	@Test
+	void testCustomBinary() {
+		var filter = binary('Foo', '_', 'Bar')
+		assertEquals 'Foo_"Bar"', filter.toFilterString()
+	}
+
+	@Test
+	void testAny() {
+		var filter = eq(any('Foo'), 5)
+		// TODO: specific index
+		assertEquals 'Foo[]=5', filter.toFilterString()
+	}
+}

--- a/src/test/groovy/gg/xp/xivapi/test/validation/ModelValidationTest.groovy
+++ b/src/test/groovy/gg/xp/xivapi/test/validation/ModelValidationTest.groovy
@@ -1,0 +1,79 @@
+package gg.xp.xivapi.test.validation
+
+import gg.xp.xivapi.XivApiClient
+import gg.xp.xivapi.exceptions.XivApiMappingException
+import groovy.transform.CompileStatic
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.function.Executable
+
+import java.util.function.Consumer
+
+@CompileStatic
+class ModelValidationTest {
+
+	static <X> void assertThrows(Class<X> exceptionType, Executable runnable, Consumer<X> checker) {
+		try {
+			runnable.execute()
+		}
+		catch (Throwable t) {
+			if (exceptionType.isInstance(t)) {
+				checker.accept(t as X)
+				return
+			}
+			else {
+				Assertions.fail "Expected exception to be ${exceptionType}, received ${t}"
+			}
+		}
+		Assertions.fail "Did not receive exception, expected ${exceptionType}"
+	}
+
+	@Test
+	void testOmitZeroesValidation1() {
+		var client = new XivApiClient()
+		assertThrows(XivApiMappingException, {
+			client.validateModel(TestModels.OmitZeroNonSheetMap)
+		}, { outer ->
+			Throwable inner = outer.cause
+			Assertions.assertInstanceOf IllegalArgumentException, inner
+			Assertions.assertEquals "@OmitZeroes only makes sense when dealing with a sheet object type", inner.message
+		})
+	}
+
+	@Test
+	void testOmitZeroesValidation2() {
+		var client = new XivApiClient()
+		assertThrows(XivApiMappingException, {
+			client.validateModel(TestModels.OmitZeroNonSheetArray)
+		}, { outer ->
+			Throwable inner = outer.cause
+			Assertions.assertInstanceOf IllegalArgumentException, inner
+			Assertions.assertEquals "@OmitZeroes only makes sense when dealing with a sheet object type", inner.message
+		})
+	}
+
+	@Test
+	void testOmitZeroesValidation3() {
+		var client = new XivApiClient()
+		assertThrows(XivApiMappingException, {
+			client.validateModel(TestModels.OmitZeroNonSheetList)
+		}, { outer ->
+			Throwable inner = outer.cause
+			Assertions.assertInstanceOf IllegalArgumentException, inner
+			Assertions.assertEquals "@OmitZeroes only makes sense when dealing with a sheet object type", inner.message
+		})
+	}
+
+	@Test
+	void testBaseName() {
+		var client = new XivApiClient()
+		assertThrows(XivApiMappingException, {
+			client.validateModel(TestModels.BadName)
+		}, { outer ->
+			Throwable inner = outer.cause
+			Assertions.assertInstanceOf IllegalArgumentException, inner
+			Assertions.assertEquals "I don't know how to map field name 'foo' to a field", inner.message
+		})
+
+	}
+}

--- a/src/test/groovy/gg/xp/xivapi/test/validation/TestModels.java
+++ b/src/test/groovy/gg/xp/xivapi/test/validation/TestModels.java
@@ -1,0 +1,28 @@
+package gg.xp.xivapi.test.validation;
+
+import gg.xp.xivapi.annotations.OmitZeroes;
+import gg.xp.xivapi.clienttypes.XivApiObject;
+
+import java.util.List;
+import java.util.Map;
+
+public class TestModels {
+	interface OmitZeroNonSheetMap extends XivApiObject {
+		@OmitZeroes
+		Map<String, String> getFoo();
+	}
+
+	interface OmitZeroNonSheetArray extends XivApiObject {
+		@OmitZeroes
+		String[] getFoo();
+	}
+
+	interface OmitZeroNonSheetList extends XivApiObject {
+		@OmitZeroes
+		List<String> getFoo();
+	}
+
+	interface BadName extends XivApiObject {
+		List<String> foo();
+	}
+}


### PR DESCRIPTION
- Adds support for treating an empty `String` as `null` instead using `@EmptyStringNull`
- Fixes some bugged combinations of nested filters
- Makes certain filters more efficient server-side
- If multiple nested objects point to the same underlying data, they will be de-duplicated to save memory
  - The behavior of this in the context of multiple entry retrieval can be controlled via `ListOptionsBuilder.listCacheMode()`
- Some error message improvements
- Public `ListOptions` constructor is deprecated, as the builder should be used instead
- Major improvements in test coverage