### PR TITLE
Fix failure handling when there is an error during iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See [Maven Central](https://central.sonatype.com/artifact/app.xivgear/xivapi-jav
 ```groovy
 dependencies {
 	// Be sure to check what the latest version is
-	implementation group: 'app.xivgear', name: 'xivapi-java', version: '0.1.5'
+	implementation group: 'app.xivgear', name: 'xivapi-java', version: '0.1.8'
 }
 ```
 
@@ -31,7 +31,7 @@ dependencies {
     <groupId>app.xivgear</groupId>
     <artifactId>xivapi-java</artifactId>
     // Be sure to check what the latest version is
-    <version>0.1.5</version>
+    <version>0.1.8</version>
 </dependency>
 ```
 

--- a/src/main/java/gg/xp/xivapi/exceptions/XivApiPaginationException.java
+++ b/src/main/java/gg/xp/xivapi/exceptions/XivApiPaginationException.java
@@ -1,0 +1,25 @@
+package gg.xp.xivapi.exceptions;
+
+/**
+ * General exception for when we are trying to paginate and something goes wrong.
+ */
+public class XivApiPaginationException extends XivApiException {
+	public XivApiPaginationException() {
+	}
+
+	public XivApiPaginationException(String message) {
+		super(message);
+	}
+
+	public XivApiPaginationException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public XivApiPaginationException(Throwable cause) {
+		super(cause);
+	}
+
+	public XivApiPaginationException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+}


### PR DESCRIPTION
If the feeder thread cannot pull for any reason (i.e. `hasNext()` or `next()` fails), then the `next()` method on the BufferedIterator will surface a failure as well, after surfacing all of the successfully-retrieved entries. 

In other words, the BufferedIterator will work normally up until the point of failure. After consuming all of the working entries, then `hasNext()` will return true, but `next()` will throw an exception.