### PR TITLE
Several improvements to multi-language values, better @as support

### DIFF
--- a/src/main/java/gg/xp/xivapi/annotations/XivApiAs.java
+++ b/src/main/java/gg/xp/xivapi/annotations/XivApiAs.java
@@ -1,0 +1,15 @@
+package gg.xp.xivapi.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Attaches an arbitrary `@as(X)` to a field.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface XivApiAs {
+	String value();
+}

--- a/src/main/java/gg/xp/xivapi/clienttypes/XivApiLangValue.java
+++ b/src/main/java/gg/xp/xivapi/clienttypes/XivApiLangValue.java
@@ -27,6 +27,6 @@ public interface XivApiLangValue<X> extends Serializable {
 	}
 
 	default X getJp() {
-		return get("jp");
+		return get("ja");
 	}
 }

--- a/src/main/java/gg/xp/xivapi/mappers/objects/ObjectFieldMapper.java
+++ b/src/main/java/gg/xp/xivapi/mappers/objects/ObjectFieldMapper.java
@@ -3,6 +3,7 @@ package gg.xp.xivapi.mappers.objects;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gg.xp.xivapi.annotations.NullIfZero;
+import gg.xp.xivapi.annotations.XivApiAs;
 import gg.xp.xivapi.annotations.XivApiLang;
 import gg.xp.xivapi.annotations.XivApiMetaField;
 import gg.xp.xivapi.annotations.XivApiRaw;
@@ -108,7 +109,11 @@ public class ObjectFieldMapper<X> implements FieldMapper<X> {
 				if (method.isAnnotationPresent(XivApiRaw.class)) {
 					fieldName += "@as(raw)";
 				}
-				else if (langAnn != null) {
+				XivApiAs genericAs = method.getAnnotation(XivApiAs.class);
+				if (genericAs != null) {
+					fieldName += "@as(%s)".formatted(genericAs.value());
+				}
+				if (langAnn != null) {
 					fieldName += "@lang(%s)".formatted(langAnn.value());
 				}
 				if (transientFieldAnn != null) {

--- a/src/test/groovy/gg/xp/xivapi/test/langtest/Action.java
+++ b/src/test/groovy/gg/xp/xivapi/test/langtest/Action.java
@@ -1,0 +1,53 @@
+package gg.xp.xivapi.test.langtest;
+
+import gg.xp.xivapi.annotations.XivApiAs;
+import gg.xp.xivapi.annotations.XivApiLang;
+import gg.xp.xivapi.annotations.XivApiRaw;
+import gg.xp.xivapi.annotations.XivApiSheet;
+import gg.xp.xivapi.annotations.XivApiTransientField;
+import gg.xp.xivapi.clienttypes.XivApiLangValue;
+import gg.xp.xivapi.clienttypes.XivApiObject;
+
+@XivApiSheet
+public interface Action extends XivApiObject {
+
+	// This field is purely to make the API not query all the fields
+	// TODO: make that the default behavior
+	String getName();
+
+	@XivApiTransientField("Description")
+	String getDescriptionDefault();
+
+	@XivApiTransientField("Description")
+	@XivApiAs("html")
+	String getDescriptionHtml();
+
+	@XivApiTransientField("Description")
+	@XivApiRaw
+	String getDescriptionRaw();
+
+	@XivApiTransientField("Description")
+	@XivApiLang("de")
+	String getDescriptionDefaultDe();
+
+	@XivApiTransientField("Description")
+	@XivApiAs("html")
+	@XivApiLang("de")
+	String getDescriptionHtmlDe();
+
+	@XivApiTransientField("Description")
+	@XivApiRaw
+	@XivApiLang("de")
+	String getDescriptionRawDe();
+
+	@XivApiTransientField("Description")
+	XivApiLangValue<String> getDescriptionAll();
+
+	@XivApiTransientField("Description")
+	@XivApiAs("html")
+	XivApiLangValue<String> getDescriptionHtmlAll();
+
+	@XivApiTransientField("Description")
+	@XivApiRaw
+	XivApiLangValue<String> getDescriptionRawAll();
+}

--- a/src/test/groovy/gg/xp/xivapi/test/langtest/AozAction.java
+++ b/src/test/groovy/gg/xp/xivapi/test/langtest/AozAction.java
@@ -23,8 +23,4 @@ public interface AozAction extends XivApiObject {
 	@XivApiTransientField("Location")
 	@XivApiLang("de")
 	Location getLocationDe();
-
-	// You can also map a sub-struct to all langs
-	@XivApiTransientField("Location")
-	XivApiLangValue<Location> getLocationsAll();
 }

--- a/src/test/groovy/gg/xp/xivapi/test/langtest/AozAction2.java
+++ b/src/test/groovy/gg/xp/xivapi/test/langtest/AozAction2.java
@@ -1,0 +1,21 @@
+package gg.xp.xivapi.test.langtest;
+
+import gg.xp.xivapi.annotations.XivApiAs;
+import gg.xp.xivapi.annotations.XivApiLang;
+import gg.xp.xivapi.annotations.XivApiRaw;
+import gg.xp.xivapi.annotations.XivApiSheet;
+import gg.xp.xivapi.annotations.XivApiTransientField;
+import gg.xp.xivapi.clienttypes.XivApiLangValue;
+import gg.xp.xivapi.clienttypes.XivApiObject;
+
+@XivApiSheet("AozAction")
+public interface AozAction2 extends XivApiObject {
+
+	// You can also map a sub-struct to all langs
+	@XivApiTransientField("Location")
+	XivApiLangValue<Location> getLocationsAll();
+
+	@XivApiTransientField
+	@XivApiAs("html")
+	XivApiLangValue<String> getDescription();
+}

--- a/src/test/groovy/gg/xp/xivapi/test/langtest/LangTest.groovy
+++ b/src/test/groovy/gg/xp/xivapi/test/langtest/LangTest.groovy
@@ -9,73 +9,75 @@ import org.junit.jupiter.api.Test
 
 import static gg.xp.xivapi.test.testutils.TestUtils.serializeAndDeserialize
 
+import static org.junit.jupiter.api.Assertions.assertEquals
+
 @CompileStatic
 class LangTest {
 	@Test
 	void testLangs() {
 		var client = new XivApiClient({ XivApiSettings.Builder it ->
-			it.schemaVersion = "exdschema@5f292f39f3deab2c43bee62b202b54ebf51e15b7-2024.08.02.0000.0000"
-			it.gameVersion = "7.05"
+			it.schemaVersion = 'exdschema@5f292f39f3deab2c43bee62b202b54ebf51e15b7-2024.08.02.0000.0000'
+			it.gameVersion = '7.05'
 		})
 
-		AozAction action = client.getById(AozAction, 5)
+		AozAction action = client.getById AozAction, 5
 
-		Assertions.assertEquals(5, action.rowId)
-		Assertions.assertEquals(93, action.location)
-		Assertions.assertEquals("the Binding Coil of Bahamut - Turn 1", action.locationFull.name)
-		Assertions.assertEquals("the Binding Coil of Bahamut - Turn 1", action.locationFull.nameStrings.en)
-		Assertions.assertEquals("Verschlungene Schatten 1", action.locationFull.nameStrings.de)
-		Assertions.assertEquals("le Labyrinthe de Bahamut I", action.locationFull.nameStrings.fr)
-		Assertions.assertEquals("大迷宮バハムート：邂逅編1", action.locationFull.nameStrings.jp)
-		Assertions.assertEquals("Verschlungene Schatten 1", action.locationDe.name)
+		assertEquals 5, action.rowId
+		assertEquals 93, action.location
+		assertEquals 'the Binding Coil of Bahamut - Turn 1', action.locationFull.name
+		assertEquals 'the Binding Coil of Bahamut - Turn 1', action.locationFull.nameStrings.en
+		assertEquals 'Verschlungene Schatten 1', action.locationFull.nameStrings.de
+		assertEquals 'le Labyrinthe de Bahamut I', action.locationFull.nameStrings.fr
+		assertEquals '大迷宮バハムート：邂逅編1', action.locationFull.nameStrings.jp
+		assertEquals 'Verschlungene Schatten 1', action.locationDe.name
 
-		Assertions.assertEquals("the Binding Coil of Bahamut - Turn 1", action.locationFull.nameStrings['en'])
-		Assertions.assertEquals("Verschlungene Schatten 1", action.locationFull.nameStrings['de'])
+		assertEquals 'the Binding Coil of Bahamut - Turn 1', action.locationFull.nameStrings['en']
+		assertEquals 'Verschlungene Schatten 1', action.locationFull.nameStrings['de']
 
 		// Make sure this serializes in a sane way
 		Map<String, String> serialized = new ObjectMapper().convertValue(action.locationFull.nameStrings, Map.class)
 
-		Assertions.assertEquals("the Binding Coil of Bahamut - Turn 1", serialized['en'])
-		Assertions.assertEquals("Verschlungene Schatten 1", serialized['de'])
+		assertEquals 'the Binding Coil of Bahamut - Turn 1', serialized['en']
+		assertEquals 'Verschlungene Schatten 1', serialized['de']
 
-		String asJson = new ObjectMapper().writeValueAsString(action.locationFull.nameStrings)
-		Assertions.assertEquals("{\"de\":\"Verschlungene Schatten 1\",\"en\":\"the Binding Coil of Bahamut - Turn 1\",\"fr\":\"le Labyrinthe de Bahamut I\",\"ja\":\"大迷宮バハムート：邂逅編1\"}", asJson)
+		String asJson = new ObjectMapper().writeValueAsString action.locationFull.nameStrings
+		assertEquals '{"de":"Verschlungene Schatten 1","en":"the Binding Coil of Bahamut - Turn 1","fr":"le Labyrinthe de Bahamut I","ja":"大迷宮バハムート：邂逅編1"}', asJson
 
 		// Test java serialization
-		AozAction rehydrated = serializeAndDeserialize(action)
+		AozAction rehydrated = serializeAndDeserialize action
 
-		Assertions.assertEquals(5, rehydrated.rowId)
-		Assertions.assertEquals(93, rehydrated.location)
-		Assertions.assertEquals("the Binding Coil of Bahamut - Turn 1", rehydrated.locationFull.name)
-		Assertions.assertEquals("Verschlungene Schatten 1", rehydrated.locationFull.nameDe)
+		assertEquals 5, rehydrated.rowId
+		assertEquals 93, rehydrated.location
+		assertEquals 'the Binding Coil of Bahamut - Turn 1', rehydrated.locationFull.name
+		assertEquals 'Verschlungene Schatten 1', rehydrated.locationFull.nameDe
 
 	}
 
 	@Test
 	void testLangs2() {
 		var client = new XivApiClient({ XivApiSettings.Builder it ->
-			it.schemaVersion = "exdschema@5f292f39f3deab2c43bee62b202b54ebf51e15b7-2024.08.02.0000.0000"
-			it.gameVersion = "7.05"
+			it.schemaVersion = 'exdschema@5f292f39f3deab2c43bee62b202b54ebf51e15b7-2024.08.02.0000.0000'
+			it.gameVersion = '7.05'
 		})
 
-		AozAction2 action = client.getById(AozAction2, 5)
+		AozAction2 action = client.getById AozAction2, 5
 
-		Assertions.assertEquals(5, action.rowId)
+		assertEquals 5, action.rowId
 
-		Assertions.assertEquals("the Binding Coil of Bahamut - Turn 1", action.locationsAll.en.name)
-		Assertions.assertEquals("Verschlungene Schatten 1", action.locationsAll.de.name)
-		Assertions.assertEquals("le Labyrinthe de Bahamut I", action.locationsAll.fr.name)
-		Assertions.assertEquals("大迷宮バハムート：邂逅編1", action.locationsAll.jp.name)
+		assertEquals 'the Binding Coil of Bahamut - Turn 1', action.locationsAll.en.name
+		assertEquals 'Verschlungene Schatten 1', action.locationsAll.de.name
+		assertEquals 'le Labyrinthe de Bahamut I', action.locationsAll.fr.name
+		assertEquals '大迷宮バハムート：邂逅編1', action.locationsAll.jp.name
 
-		Assertions.assertEquals("An industrial form of machina-based aetherial manipulation developed and adapted by the Allagan Empire. Through the compression of ambient lightning-aspected aether, the caster (or casting machina) floods the vicinity with highly charged arcs of electricity.", action.description.en)
+		assertEquals 'An industrial form of machina-based aetherial manipulation developed and adapted by the Allagan Empire. Through the compression of ambient lightning-aspected aether, the caster (or casting machina) floods the vicinity with highly charged arcs of electricity.', action.description.en
 
 		// Test java serialization
-		AozAction2 rehydrated = serializeAndDeserialize(action)
+		AozAction2 rehydrated = serializeAndDeserialize action
 
-		Assertions.assertEquals("the Binding Coil of Bahamut - Turn 1", rehydrated.locationsAll.en.name)
-		Assertions.assertEquals("Verschlungene Schatten 1", rehydrated.locationsAll.de.name)
-		Assertions.assertEquals("le Labyrinthe de Bahamut I", rehydrated.locationsAll.fr.name)
-		Assertions.assertEquals("大迷宮バハムート：邂逅編1", rehydrated.locationsAll.jp.name)
+		assertEquals 'the Binding Coil of Bahamut - Turn 1', rehydrated.locationsAll.en.name
+		assertEquals 'Verschlungene Schatten 1', rehydrated.locationsAll.de.name
+		assertEquals 'le Labyrinthe de Bahamut I', rehydrated.locationsAll.fr.name
+		assertEquals '大迷宮バハムート：邂逅編1', rehydrated.locationsAll.jp.name
 
 
 	}
@@ -83,32 +85,32 @@ class LangTest {
 	@Test
 	void testLangs3() {
 		var client = new XivApiClient({ XivApiSettings.Builder it ->
-			it.schemaVersion = "exdschema@5f292f39f3deab2c43bee62b202b54ebf51e15b7-2024.08.02.0000.0000"
-			it.gameVersion = "7.05"
+			it.schemaVersion = 'exdschema@5f292f39f3deab2c43bee62b202b54ebf51e15b7-2024.08.02.0000.0000'
+			it.gameVersion = '7.05'
 		})
 
-		Action action = client.getById(Action, 7395)
+		Action action = client.getById Action, 7395
 
 		String dflt = 'Increases damage dealt by 15%.\nDuration: 20s\nAdditional Effect: Grants Fire\'s Rumination\nDuration: 20s'
 		String html = 'Increases damage dealt by 15%.<br><span style="color:rgba(0,204,34,1);">Duration:</span> 20s<br><span style="color:rgba(0,204,34,1);">Additional Effect: </span>Grants <span style="color:rgba(255,255,102,1);">Fire\'s Rumination</span><br><span style="color:rgba(0,204,34,1);">Duration: </span>20s'
 		String de = 'Dein ausgeteilter Schaden ist um 15 % erhöht.\nDauer: 20 Sekunden\nZusatzeffekt: Gewährt dir Himmel und Erde.\nDauer: 20 Sekunden'
 		String deHtml = 'Dein ausgeteilter Schaden ist um 15 % erhöht.<br>Dauer: 20 Sekunden<br>Zusatzeffekt: Gewährt dir <span style="color:rgba(255,255,102,1);">Himmel und Erde</span>.<br>Dauer: 20 Sekunden'
 
-		Assertions.assertEquals(dflt, action.descriptionDefault)
-		Assertions.assertEquals(dflt, action.descriptionRaw)
-		Assertions.assertEquals(html, action.descriptionHtml)
+		assertEquals dflt, action.descriptionDefault
+		assertEquals dflt, action.descriptionRaw
+		assertEquals html, action.descriptionHtml
 
-		Assertions.assertEquals(de, action.descriptionDefaultDe)
-		Assertions.assertEquals(de, action.descriptionRawDe)
-		Assertions.assertEquals(deHtml, action.descriptionHtmlDe)
+		assertEquals de, action.descriptionDefaultDe
+		assertEquals de, action.descriptionRawDe
+		assertEquals deHtml, action.descriptionHtmlDe
 
-		Assertions.assertEquals(dflt, action.descriptionAll.en)
-		Assertions.assertEquals(dflt, action.descriptionRawAll.en)
-		Assertions.assertEquals(html, action.descriptionHtmlAll.en)
+		assertEquals dflt, action.descriptionAll.en
+		assertEquals dflt, action.descriptionRawAll.en
+		assertEquals html, action.descriptionHtmlAll.en
 
-		Assertions.assertEquals(de, action.descriptionAll.de)
-		Assertions.assertEquals(de, action.descriptionRawAll.de)
-		Assertions.assertEquals(deHtml, action.descriptionHtmlAll.de)
+		assertEquals de, action.descriptionAll.de
+		assertEquals de, action.descriptionRawAll.de
+		assertEquals deHtml, action.descriptionHtmlAll.de
 
 	}
 }

--- a/src/test/groovy/gg/xp/xivapi/test/langtest/LangTest.groovy
+++ b/src/test/groovy/gg/xp/xivapi/test/langtest/LangTest.groovy
@@ -23,10 +23,11 @@ class LangTest {
 		Assertions.assertEquals(5, action.rowId)
 		Assertions.assertEquals(93, action.location)
 		Assertions.assertEquals("the Binding Coil of Bahamut - Turn 1", action.locationFull.name)
-		Assertions.assertEquals("Verschlungene Schatten 1", action.locationFull.nameDe)
+		Assertions.assertEquals("the Binding Coil of Bahamut - Turn 1", action.locationFull.nameStrings.en)
+		Assertions.assertEquals("Verschlungene Schatten 1", action.locationFull.nameStrings.de)
+		Assertions.assertEquals("le Labyrinthe de Bahamut I", action.locationFull.nameStrings.fr)
+		Assertions.assertEquals("大迷宮バハムート：邂逅編1", action.locationFull.nameStrings.jp)
 		Assertions.assertEquals("Verschlungene Schatten 1", action.locationDe.name)
-
-		Assertions.assertEquals("Verschlungene Schatten 1", action.locationsAll.de.name)
 
 		Assertions.assertEquals("the Binding Coil of Bahamut - Turn 1", action.locationFull.nameStrings['en'])
 		Assertions.assertEquals("Verschlungene Schatten 1", action.locationFull.nameStrings['de'])
@@ -47,6 +48,67 @@ class LangTest {
 		Assertions.assertEquals(93, rehydrated.location)
 		Assertions.assertEquals("the Binding Coil of Bahamut - Turn 1", rehydrated.locationFull.name)
 		Assertions.assertEquals("Verschlungene Schatten 1", rehydrated.locationFull.nameDe)
+
+	}
+
+	@Test
+	void testLangs2() {
+		var client = new XivApiClient({ XivApiSettings.Builder it ->
+			it.schemaVersion = "exdschema@5f292f39f3deab2c43bee62b202b54ebf51e15b7-2024.08.02.0000.0000"
+			it.gameVersion = "7.05"
+		})
+
+		AozAction2 action = client.getById(AozAction2, 5)
+
+		Assertions.assertEquals(5, action.rowId)
+
+		Assertions.assertEquals("the Binding Coil of Bahamut - Turn 1", action.locationsAll.en.name)
+		Assertions.assertEquals("Verschlungene Schatten 1", action.locationsAll.de.name)
+		Assertions.assertEquals("le Labyrinthe de Bahamut I", action.locationsAll.fr.name)
+		Assertions.assertEquals("大迷宮バハムート：邂逅編1", action.locationsAll.jp.name)
+
+		Assertions.assertEquals("An industrial form of machina-based aetherial manipulation developed and adapted by the Allagan Empire. Through the compression of ambient lightning-aspected aether, the caster (or casting machina) floods the vicinity with highly charged arcs of electricity.", action.description.en)
+
+		// Test java serialization
+		AozAction2 rehydrated = serializeAndDeserialize(action)
+
+		Assertions.assertEquals("the Binding Coil of Bahamut - Turn 1", rehydrated.locationsAll.en.name)
+		Assertions.assertEquals("Verschlungene Schatten 1", rehydrated.locationsAll.de.name)
+		Assertions.assertEquals("le Labyrinthe de Bahamut I", rehydrated.locationsAll.fr.name)
+		Assertions.assertEquals("大迷宮バハムート：邂逅編1", rehydrated.locationsAll.jp.name)
+
+
+	}
+
+	@Test
+	void testLangs3() {
+		var client = new XivApiClient({ XivApiSettings.Builder it ->
+			it.schemaVersion = "exdschema@5f292f39f3deab2c43bee62b202b54ebf51e15b7-2024.08.02.0000.0000"
+			it.gameVersion = "7.05"
+		})
+
+		Action action = client.getById(Action, 7395)
+
+		String dflt = 'Increases damage dealt by 15%.\nDuration: 20s\nAdditional Effect: Grants Fire\'s Rumination\nDuration: 20s'
+		String html = 'Increases damage dealt by 15%.<br><span style="color:rgba(0,204,34,1);">Duration:</span> 20s<br><span style="color:rgba(0,204,34,1);">Additional Effect: </span>Grants <span style="color:rgba(255,255,102,1);">Fire\'s Rumination</span><br><span style="color:rgba(0,204,34,1);">Duration: </span>20s'
+		String de = 'Dein ausgeteilter Schaden ist um 15 % erhöht.\nDauer: 20 Sekunden\nZusatzeffekt: Gewährt dir Himmel und Erde.\nDauer: 20 Sekunden'
+		String deHtml = 'Dein ausgeteilter Schaden ist um 15 % erhöht.<br>Dauer: 20 Sekunden<br>Zusatzeffekt: Gewährt dir <span style="color:rgba(255,255,102,1);">Himmel und Erde</span>.<br>Dauer: 20 Sekunden'
+
+		Assertions.assertEquals(dflt, action.descriptionDefault)
+		Assertions.assertEquals(dflt, action.descriptionRaw)
+		Assertions.assertEquals(html, action.descriptionHtml)
+
+		Assertions.assertEquals(de, action.descriptionDefaultDe)
+		Assertions.assertEquals(de, action.descriptionRawDe)
+		Assertions.assertEquals(deHtml, action.descriptionHtmlDe)
+
+		Assertions.assertEquals(dflt, action.descriptionAll.en)
+		Assertions.assertEquals(dflt, action.descriptionRawAll.en)
+		Assertions.assertEquals(html, action.descriptionHtmlAll.en)
+
+		Assertions.assertEquals(de, action.descriptionAll.de)
+		Assertions.assertEquals(de, action.descriptionRawAll.de)
+		Assertions.assertEquals(deHtml, action.descriptionHtmlAll.de)
 
 	}
 }

--- a/src/test/groovy/gg/xp/xivapi/test/langtest/LocationIntl.java
+++ b/src/test/groovy/gg/xp/xivapi/test/langtest/LocationIntl.java
@@ -2,6 +2,7 @@ package gg.xp.xivapi.test.langtest;
 
 import gg.xp.xivapi.annotations.XivApiField;
 import gg.xp.xivapi.annotations.XivApiLang;
+import gg.xp.xivapi.annotations.XivApiRaw;
 import gg.xp.xivapi.clienttypes.XivApiLangValue;
 import gg.xp.xivapi.clienttypes.XivApiObject;
 
@@ -12,6 +13,7 @@ public interface LocationIntl extends XivApiObject {
 	// Explicitly request DE
 	@XivApiField("Name")
 	@XivApiLang("de")
+	@XivApiRaw
 	String getNameDe();
 
 	// Request all known languages


### PR DESCRIPTION
- Fixes #13 (jp -> ja)
- Fixes #12 (make XivApiLangValue respect transient flag, and fix the test that was missing this)
- Closes #11 - adds generic `@XivApiAs` annotation to allow for arbitrary `@as` decorators
- Make `@XivApiAs` and `@XivApiRaw` work through `XivApiLangValue`