### PR TITLE
Support subrow querying

### DIFF
--- a/src/main/java/gg/xp/xivapi/clienttypes/XivApiSubrowObject.java
+++ b/src/main/java/gg/xp/xivapi/clienttypes/XivApiSubrowObject.java
@@ -1,0 +1,8 @@
+package gg.xp.xivapi.clienttypes;
+
+import gg.xp.xivapi.annotations.XivApiMetaField;
+
+public interface XivApiSubrowObject extends XivApiObject {
+	@XivApiMetaField("subrow_id")
+	int getSubrowId();
+}

--- a/src/test/groovy/gg/xp/xivapi/test/subrow/MapMarker.java
+++ b/src/test/groovy/gg/xp/xivapi/test/subrow/MapMarker.java
@@ -1,0 +1,8 @@
+package gg.xp.xivapi.test.subrow;
+
+import gg.xp.xivapi.clienttypes.XivApiSubrowObject;
+
+public interface MapMarker extends XivApiSubrowObject {
+	int getX();
+	int getY();
+}

--- a/src/test/groovy/gg/xp/xivapi/test/subrow/SubRowTest.groovy
+++ b/src/test/groovy/gg/xp/xivapi/test/subrow/SubRowTest.groovy
@@ -1,0 +1,60 @@
+package gg.xp.xivapi.test.subrow
+
+import gg.xp.xivapi.XivApiClient
+import gg.xp.xivapi.pagination.XivApiPaginator
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+
+class SubRowTest {
+
+	@Test
+	void subrowSingleTest() {
+		var client = new XivApiClient()
+		MapMarker marker = client.getBySubrowId MapMarker, 2, 1
+		assertEquals 2, marker.rowId
+		assertEquals 1, marker.subrowId
+		assertEquals 300, marker.x
+		assertEquals 500, marker.y
+	}
+
+	@Test
+	void subrowSingleBackCompatTest() {
+		var client = new XivApiClient()
+		// 2 translates to 2:0
+		MapMarker marker = client.getById MapMarker, 2
+		assertEquals 2, marker.rowId
+		assertEquals 0, marker.subrowId
+		assertEquals 256, marker.x
+		assertEquals 128, marker.y
+	}
+
+	@Test
+	void subrowListTest() {
+		var client = new XivApiClient()
+		XivApiPaginator<MapMarker> paginator = client.getListIterator MapMarker;
+		{
+			MapMarker marker = paginator.next()
+			assertEquals 0, marker.rowId
+			assertEquals 0, marker.subrowId
+			assertEquals 0, marker.x
+			assertEquals 0, marker.y
+		}
+		{
+			MapMarker marker = paginator.next()
+			assertEquals 1, marker.rowId
+			assertEquals 0, marker.subrowId
+			assertEquals 256, marker.x
+			assertEquals 128, marker.y
+		}
+		{
+			MapMarker marker = paginator.next()
+			assertEquals 1, marker.rowId
+			assertEquals 1, marker.subrowId
+			assertEquals 300, marker.x
+			assertEquals 500, marker.y
+		}
+
+	}
+
+}


### PR DESCRIPTION
To use subrows:
- Your interface type should extend XivApiSubrowObject
- You can use the method XivApiClient.getBySubrowId