### PR TITLE
Allow unwrapping of wrapped values

### DIFF
--- a/src/main/java/gg/xp/xivapi/clienttypes/XivApiSettings.java
+++ b/src/main/java/gg/xp/xivapi/clienttypes/XivApiSettings.java
@@ -6,6 +6,12 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.function.Consumer;
 
+/**
+ * Class which describes xivapi settings.
+ * <p>
+ * Use {@link #newBuilder()} to construct an instance. See the method javadocs on {@link Builder} for descriptions
+ * of what each setting does.
+ */
 public final class XivApiSettings {
 
 	private final boolean strict;
@@ -15,8 +21,9 @@ public final class XivApiSettings {
 	private final @Nullable String gameVersion;
 	private final @Nullable String schemaVersion;
 	private final String userAgent;
+	private final boolean autoUnwrapValue;
 
-	private XivApiSettings(boolean strict, URI baseUri, @Nullable URI baseAssetUri, int concurrencyLimit, @Nullable String gameVersion, @Nullable String schemaVersion, String userAgent) {
+	private XivApiSettings(boolean strict, URI baseUri, @Nullable URI baseAssetUri, int concurrencyLimit, @Nullable String gameVersion, @Nullable String schemaVersion, String userAgent, boolean autoUnwrapValue) {
 		this.strict = strict;
 		this.baseUri = baseUri;
 		this.baseAssetUri = baseAssetUri;
@@ -24,6 +31,7 @@ public final class XivApiSettings {
 		this.gameVersion = gameVersion;
 		this.schemaVersion = schemaVersion;
 		this.userAgent = userAgent;
+		this.autoUnwrapValue = autoUnwrapValue;
 	}
 
 	public boolean isStrict() {
@@ -54,6 +62,10 @@ public final class XivApiSettings {
 		return userAgent;
 	}
 
+	public boolean getAutoUnwrapValue() {
+		return autoUnwrapValue;
+	}
+
 	public static Builder newBuilder() {
 		return new Builder();
 	}
@@ -67,6 +79,7 @@ public final class XivApiSettings {
 		@Nullable String gameVersion;
 		@Nullable String schemaVersion;
 		String userAgent = "Xivapi-Java";
+		boolean autoUnwrapValue = true;
 
 		{
 			try {
@@ -104,37 +117,80 @@ public final class XivApiSettings {
 			return this;
 		}
 
+		/**
+		 * Set a concurrency limit for API requests. Defaults to 10. Modify responsibly. Don't tip over Xivapi, but if
+		 * you're using your own Boilmaster instance, go wild.
+		 *
+		 * @param concurrencyLimit Concurrency limit override.
+		 * @return The builder
+		 */
 		public Builder setConcurrencyLimit(int concurrencyLimit) {
+			// TODO: this should let you pass in a semaphore directly, so that you can have a concurrency limiter across
+			// multiple client instances.
 			this.concurrencyLimit = concurrencyLimit;
 			return this;
 		}
 
+		/**
+		 * Set a specific game version to use.
+		 *
+		 * @param gameVersion The game version to use for API requests.
+		 * @return The builder
+		 */
 		public Builder setGameVersion(@Nullable String gameVersion) {
 			this.gameVersion = gameVersion;
 			return this;
 		}
 
+		/**
+		 * Set a specific game version to use.
+		 *
+		 * @param schemaVersion The schema version to use for API requests.
+		 * @return The builder
+		 */
 		public Builder setSchemaVersion(@Nullable String schemaVersion) {
 			this.schemaVersion = schemaVersion;
 			return this;
 		}
-//
-//		public Builder configure(Function<Builder, Builder> configurer) {
-//			return configurer.apply(this);
-//		}
 
+		/**
+		 * Override the default user agent.
+		 *
+		 * @param userAgent The user agent string to use.
+		 * @return The builder.
+		 */
 		public Builder setUserAgent(String userAgent) {
 			this.userAgent = userAgent;
 			return this;
 		}
 
+		/**
+		 * Set whether the client will detect and unwrap values of the form {@code {"value":actualValue}}. Defaults to
+		 * true. If set to false, then those will instead throw an exception, and you will need to instead use a
+		 * XivApiStruct type to deserialize that value.
+		 *
+		 * @param autoUnwrapValue Whether to automatically unwrap wrapped values.
+		 * @return The builder.
+		 */
+		public Builder setAutoUnwrapValue(boolean autoUnwrapValue) {
+			this.autoUnwrapValue = autoUnwrapValue;
+			return this;
+		}
+
+		/**
+		 * Method that allows you to supply configurations to the builder in a re-usable manner, without breaking
+		 * the builder pattern by passing the builder into another method.
+		 *
+		 * @param configurer A function that takes the builder as an argument. It should modify the builder in-place.
+		 * @return The builder.
+		 */
 		public Builder configure(Consumer<Builder> configurer) {
 			configurer.accept(this);
 			return this;
 		}
 
 		public XivApiSettings build() {
-			return new XivApiSettings(strict, baseUri, baseAssetUri, concurrencyLimit, gameVersion, schemaVersion, userAgent);
+			return new XivApiSettings(strict, baseUri, baseAssetUri, concurrencyLimit, gameVersion, schemaVersion, userAgent, autoUnwrapValue);
 		}
 	}
 

--- a/src/main/java/gg/xp/xivapi/clienttypes/XivApiSettings.java
+++ b/src/main/java/gg/xp/xivapi/clienttypes/XivApiSettings.java
@@ -62,7 +62,7 @@ public final class XivApiSettings {
 		return userAgent;
 	}
 
-	public boolean getAutoUnwrapValue() {
+	public boolean isAutoUnwrapValue() {
 		return autoUnwrapValue;
 	}
 
@@ -90,6 +90,14 @@ public final class XivApiSettings {
 			}
 		}
 
+		/**
+		 * Enable stricter handling of null/undefined/missing/zero values. Defaults to true. Disabling this will cause
+		 * null (for objects) or zero/false (for primitives) to be returned instead of throwing an exception in most
+		 * circumstances.
+		 *
+		 * @param strict Whether to enable strict mode.
+		 * @return The builder
+		 */
 		public Builder setStrict(boolean strict) {
 			this.strict = strict;
 			return this;

--- a/src/main/java/gg/xp/xivapi/mappers/BasicValueMapper.java
+++ b/src/main/java/gg/xp/xivapi/mappers/BasicValueMapper.java
@@ -39,7 +39,26 @@ public class BasicValueMapper<X> implements FieldMapper<X> {
 			return out;
 		}
 		catch (Throwable t) {
-			throw new XivApiException("Error deserializing value %s into %s".formatted(current, fieldType), t);
+			// Special case for when a breaking schema change turns something into `{"value": <value>}` instead of
+			// just `value`.
+			boolean autoUnwrapValue = context.settings().getAutoUnwrapValue();
+			Throwable secondary = null;
+			if (autoUnwrapValue) {
+				if (current.isObject() && current.has("value")) {
+					try {
+						return getValue(current.get("value"), context);
+					}
+					catch (Throwable inner) {
+						// Ignore this and just re-throw the original exception
+						secondary = inner;
+					}
+				}
+			}
+			XivApiException exc = new XivApiException("Error deserializing value %s into %s".formatted(current, fieldType), t);
+			if (secondary != null) {
+				exc.addSuppressed(secondary);
+			}
+			throw exc;
 		}
 	}
 

--- a/src/main/java/gg/xp/xivapi/mappers/BasicValueMapper.java
+++ b/src/main/java/gg/xp/xivapi/mappers/BasicValueMapper.java
@@ -7,8 +7,6 @@ import gg.xp.xivapi.exceptions.XivApiException;
 import gg.xp.xivapi.impl.XivApiContext;
 
 import java.lang.reflect.Method;
-import java.util.List;
-import java.util.Objects;
 
 /**
  * Mapper for an individual value (numeric, string, boolean)
@@ -41,7 +39,7 @@ public class BasicValueMapper<X> implements FieldMapper<X> {
 		catch (Throwable t) {
 			// Special case for when a breaking schema change turns something into `{"value": <value>}` instead of
 			// just `value`.
-			boolean autoUnwrapValue = context.settings().getAutoUnwrapValue();
+			boolean autoUnwrapValue = context.settings().isAutoUnwrapValue();
 			Throwable secondary = null;
 			if (autoUnwrapValue) {
 				if (current.isObject() && current.has("value")) {

--- a/src/main/java/gg/xp/xivapi/mappers/objects/ObjectInvocationHandler.java
+++ b/src/main/java/gg/xp/xivapi/mappers/objects/ObjectInvocationHandler.java
@@ -132,6 +132,11 @@ public class ObjectInvocationHandler implements InvocationHandler, Serializable 
 	}
 
 	// TODO: figure out a way to also allow this to make use of KeyedAlikeMap (check if worth)
+	/*
+	This is harder than it seems at first. You have to have each of them reference *some* kind of common object, like
+	the KeyedAlikeMapFactory, but if the keys aren't serializable, then you can't use that. We have to figure out a way
+	to convert to and from the "safe" keys but only on a single centralized instance.
+	 */
 	private record SerializableForm(Map<MethodMetadata, Object> methodMetaMap, boolean strict) implements Serializable {
 		@Serial
 		private Object readResolve() {

--- a/src/test/groovy/gg/xp/xivapi/test/autounwrapvalue/AutoUnwrapValueTest.groovy
+++ b/src/test/groovy/gg/xp/xivapi/test/autounwrapvalue/AutoUnwrapValueTest.groovy
@@ -1,0 +1,43 @@
+package gg.xp.xivapi.test.autounwrapvalue
+
+import gg.xp.xivapi.XivApiClient
+import gg.xp.xivapi.clienttypes.XivApiObject
+import gg.xp.xivapi.clienttypes.XivApiSettings
+import gg.xp.xivapi.exceptions.XivApiDeserializationException
+import groovy.transform.CompileStatic
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@CompileStatic
+class AutoUnwrapValueTest {
+
+	private static final String schemaVersion = "exdschema@5f292f39f3deab2c43bee62b202b54ebf51e15b7-2024.08.02.0000.0000"
+
+	interface Item extends XivApiObject {
+		List<Integer> getBaseParam();
+	}
+
+	@Test
+	void autoUnwrapEnabledTest() {
+		XivApiClient client = new XivApiClient({ XivApiSettings.Builder it ->
+			it.autoUnwrapValue = true
+			it.schemaVersion = schemaVersion
+			it.gameVersion = "7.05"
+		})
+		Item item = client.getById Item, 24856
+		// Even though there are other fields in BaseParam, that's fine - we only want the "value" field.
+		Assertions.assertEquals 5, item.baseParam[0]
+	}
+
+	@Test
+	void autoUnwrapDisabledTest() {
+		XivApiClient client = new XivApiClient({ XivApiSettings.Builder it ->
+			it.autoUnwrapValue = false
+			it.schemaVersion = schemaVersion
+			it.gameVersion = "7.05"
+		})
+		Assertions.assertThrows XivApiDeserializationException, {
+			client.getById Item, 24856
+		}
+	}
+}

--- a/src/test/groovy/gg/xp/xivapi/test/autounwrapvalue/AutoUnwrapValueTest.groovy
+++ b/src/test/groovy/gg/xp/xivapi/test/autounwrapvalue/AutoUnwrapValueTest.groovy
@@ -20,7 +20,7 @@ class AutoUnwrapValueTest {
 	@Test
 	void autoUnwrapEnabledTest() {
 		XivApiClient client = new XivApiClient({ XivApiSettings.Builder it ->
-			it.autoUnwrapValue = true
+			// It's the default, we don't need to set it
 			it.schemaVersion = schemaVersion
 			it.gameVersion = "7.05"
 		})


### PR DESCRIPTION
To better deal with issues like the recent ItemAction issue, this adds a flag (defaulting to true) to allow unwrapping of `{"value": actualValue}` as if it were just `actualValue`.