### PR TITLE
Proper KeyedAlikeMap serialization

### DIFF
--- a/src/main/java/gg/xp/xivapi/collections/KeySerDe.java
+++ b/src/main/java/gg/xp/xivapi/collections/KeySerDe.java
@@ -1,0 +1,8 @@
+package gg.xp.xivapi.collections;
+
+import java.io.Serializable;
+
+public interface KeySerDe<K, S extends Serializable> extends Serializable {
+	S toSerializableForm(K key);
+	K fromSerializeableForm(S serializable);
+}

--- a/src/main/java/gg/xp/xivapi/collections/KeyedAlikeMap.java
+++ b/src/main/java/gg/xp/xivapi/collections/KeyedAlikeMap.java
@@ -3,6 +3,7 @@ package gg.xp.xivapi.collections;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.Serializable;
 import java.util.AbstractCollection;
 import java.util.AbstractSet;
 import java.util.Arrays;
@@ -32,7 +33,7 @@ import java.util.stream.Stream;
  * @see KeyedAlikeMapFactory
  */
 @SuppressWarnings("Convert2streamapi") // performance
-public class KeyedAlikeMap<K, V> implements Map<K, V> {
+public class KeyedAlikeMap<K, V> implements Map<K, V>, Serializable {
 
 	/**
 	 * Contains the universe of keys. The integers represent the index that the value corresponding to the key will be
@@ -47,11 +48,16 @@ public class KeyedAlikeMap<K, V> implements Map<K, V> {
 	 * state of the map is to have no entries.
 	 */
 	private final Object[] values;
+
 	/**
 	 * Sentry value for elements which have explicitly been set to null.
 	 * Unset values instead use a literal null.
 	 */
-	private static final Object NULL_MARKER = new Object();
+	private static final Serializable NULL_MARKER = NullMarkerEnum.INSTANCE;
+
+	private enum NullMarkerEnum {
+		INSTANCE
+	}
 
 	KeyedAlikeMap(Map<K, Integer> keyMapping) {
 		//noinspection AssignmentOrReturnOfFieldWithMutableType
@@ -108,6 +114,7 @@ public class KeyedAlikeMap<K, V> implements Map<K, V> {
 
 	/**
 	 * Get the index for a key. Throws an exception if the key is not in the allowed key set.
+	 *
 	 * @param key The key
 	 * @return The corresponding value index
 	 * @throws IllegalArgumentException If the key is not in the allowed key set

--- a/src/main/java/gg/xp/xivapi/collections/KeyedAlikeMapFactory.java
+++ b/src/main/java/gg/xp/xivapi/collections/KeyedAlikeMapFactory.java
@@ -17,19 +17,55 @@ import java.util.Set;
 public class KeyedAlikeMapFactory<K> {
 	private final Map<K, Integer> keyMapping;
 
+	/**
+	 * Constructs a KeyedAlikeMapFactory for the given set of keys.
+	 * <p>
+	 * Note that resulting maps will only be serializable if the keys are serializable.
+	 *
+	 * @param keys The set of all possible keys.
+	 */
 	public KeyedAlikeMapFactory(Set<K> keys) {
+		this.keyMapping = createKeyMapping(keys);
+	}
+
+	/**
+	 * Constructor that also accepts a serde helper, so that maps with non-serializable keys can still be serialized.
+	 *
+	 * @param keys  The keys
+	 * @param serDe A helper to convert the keys to/from a serializable for
+	 */
+	public KeyedAlikeMapFactory(Set<K> keys, KeySerDe<K, ?> serDe) {
+		Map<K, Integer> map = createKeyMapping(keys);
+		this.keyMapping = new MapSerializationProxy<>(map, serDe);
+	}
+
+	private Map<K, Integer> createKeyMapping(Set<K> keys) {
 		Map<K, Integer> map = new HashMap<>();
 		int count = 0;
 		for (K key : keys) {
 			map.put(key, count++);
 		}
-		this.keyMapping = map;
+		return map;
 	}
 
+	/**
+	 * Create an empty map
+	 *
+	 * @return An empty map
+	 * @param <V> The type of values
+	 */
 	public <V> KeyedAlikeMap<K, V> create() {
 		return new KeyedAlikeMap<>(keyMapping);
 	}
 
+	/**
+	 * Create a map from the given values
+	 *
+	 * @param values The initial values
+	 * @return A map with the initial values
+	 * @param <V> The type of values
+	 * @throws IllegalArgumentException when a key in the initial is not in the set of keys handled by this factory
+	 */
 	public <V> KeyedAlikeMap<K, V> create(Map<K, V> values) {
 		KeyedAlikeMap<K, V> out = new KeyedAlikeMap<>(keyMapping);
 		out.putAll(values);

--- a/src/main/java/gg/xp/xivapi/collections/MapSerializationProxy.java
+++ b/src/main/java/gg/xp/xivapi/collections/MapSerializationProxy.java
@@ -1,0 +1,143 @@
+package gg.xp.xivapi.collections;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.ObjectStreamException;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Proxy for a map that allows us to plug in a serde for the keys.
+ * The values must already be serializable.
+ *
+ * @param <K>
+ * @param <V>
+ */
+public class MapSerializationProxy<K, V> implements Map<K, V>, Serializable {
+
+	@Serial
+	private static final long serialVersionUID = 2L;
+
+	private final Map<K, V> underlying;
+	private final KeySerDe<K, ? extends Serializable> serDe;
+
+	@SuppressWarnings("AssignmentOrReturnOfFieldWithMutableType") // We specifically do not want an independent copy
+	public MapSerializationProxy(Map<K, V> underlying, KeySerDe<K, ? extends Serializable> serDe) {
+		this.underlying = underlying;
+		this.serDe = serDe;
+	}
+
+	private record SerializableForm<K, V, S extends Serializable>(
+			Map<S, V> serializableMap,
+			KeySerDe<K, S> serDe
+	) implements Serializable {
+		@Serial
+		private Object readResolve() {
+			Map<K, V> underlying = new HashMap<>(serializableMap.size());
+			for (var entry : serializableMap.entrySet()) {
+				underlying.put(serDe.fromSerializeableForm(entry.getKey()), entry.getValue());
+			}
+			return new MapSerializationProxy<>(underlying, serDe);
+		}
+	}
+
+	@Serial
+	@SuppressWarnings("unchecked")
+	private Object writeReplace() throws ObjectStreamException {
+		Map<Serializable, V> serializableMap = new HashMap<>(underlying.size());
+		for (var entry : underlying.entrySet()) {
+			serializableMap.put(serDe.toSerializableForm(entry.getKey()), entry.getValue());
+		}
+		return new SerializableForm<>(serializableMap, ((KeySerDe<K, Serializable>) serDe));
+	}
+
+	@Override
+	public int size() {
+		return underlying.size();
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return underlying.isEmpty();
+	}
+
+	@Override
+	public boolean containsKey(Object key) {
+		return underlying.containsKey(key);
+	}
+
+	@Override
+	public boolean containsValue(Object value) {
+		return underlying.containsValue(value);
+	}
+
+	@Override
+	public V get(Object key) {
+		return underlying.get(key);
+	}
+
+	@Nullable
+	@Override
+	public V put(K key, V value) {
+		return underlying.put(key, value);
+	}
+
+	@Override
+	public V remove(Object key) {
+		return underlying.remove(key);
+	}
+
+	@Override
+	public void putAll(@NotNull Map<? extends K, ? extends V> m) {
+		underlying.putAll(m);
+	}
+
+	@Override
+	public void clear() {
+		underlying.clear();
+	}
+
+	@NotNull
+	@Override
+	public Set<K> keySet() {
+		return underlying.keySet();
+	}
+
+	@NotNull
+	@Override
+	public Collection<V> values() {
+		return underlying.values();
+	}
+
+	@NotNull
+	@Override
+	public Set<Entry<K, V>> entrySet() {
+		return underlying.entrySet();
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o instanceof MapSerializationProxy<?, ?> other) {
+			return Objects.equals(underlying, other.underlying);
+		}
+		return underlying.equals(o);
+	}
+
+	@Override
+	public int hashCode() {
+		return underlying.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return underlying.toString();
+	}
+}

--- a/src/main/java/gg/xp/xivapi/mappers/objects/ObjectFieldMapper.java
+++ b/src/main/java/gg/xp/xivapi/mappers/objects/ObjectFieldMapper.java
@@ -12,7 +12,9 @@ import gg.xp.xivapi.annotations.XivApiTransientField;
 import gg.xp.xivapi.clienttypes.XivApiBase;
 import gg.xp.xivapi.clienttypes.XivApiLangValue;
 import gg.xp.xivapi.clienttypes.XivApiObject;
+import gg.xp.xivapi.collections.KeySerDe;
 import gg.xp.xivapi.collections.KeyedAlikeMapFactory;
+import gg.xp.xivapi.mappers.objects.serialization.MethodKeySerDe;
 import gg.xp.xivapi.exceptions.XivApiDeserializationException;
 import gg.xp.xivapi.exceptions.XivApiException;
 import gg.xp.xivapi.impl.XivApiContext;
@@ -28,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.net.URI;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -132,7 +133,8 @@ public class ObjectFieldMapper<X> implements FieldMapper<X> {
 		allMethods.add(ridMethod);
 		allMethods.add(svMethod);
 		allMethods.add(tsMethod);
-		this.kaMapFactory = new KeyedAlikeMapFactory<>(allMethods);
+		KeySerDe<Method, ?> serDe = new MethodKeySerDe();
+		this.kaMapFactory = new KeyedAlikeMapFactory<>(allMethods, serDe);
 	}
 
 	@Override

--- a/src/main/java/gg/xp/xivapi/mappers/objects/ObjectInvocationHandler.java
+++ b/src/main/java/gg/xp/xivapi/mappers/objects/ObjectInvocationHandler.java
@@ -9,23 +9,17 @@ import gg.xp.xivapi.mappers.util.MappingUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ObjectStreamException;
 import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 public class ObjectInvocationHandler implements InvocationHandler, Serializable {
 
 	private static final Logger log = LoggerFactory.getLogger(ObjectInvocationHandler.class);
-
-	@Serial
-	private static final long serialVersionUID = -7240936731264081326L;
 
 	private static final Method equalsMethod;
 	private static final Method hashCodeMethod;
@@ -42,9 +36,12 @@ public class ObjectInvocationHandler implements InvocationHandler, Serializable 
 		}
 	}
 
+	@Serial
+	private static final long serialVersionUID = 2L;
 	private final Map<Method, Object> methodValueMap;
 	private final boolean strict;
 
+	@SuppressWarnings("AssignmentOrReturnOfFieldWithMutableType") // We don't want a copy for memory reasons
 	public ObjectInvocationHandler(Map<Method, Object> methodValueMap, boolean strict) {
 		this.methodValueMap = methodValueMap;
 		this.strict = strict;
@@ -122,93 +119,4 @@ public class ObjectInvocationHandler implements InvocationHandler, Serializable 
 		return value;
 	}
 
-	@Serial
-	private Object writeReplace() throws ObjectStreamException {
-		Map<MethodMetadata, Object> metaMap = new HashMap<>(methodValueMap.size());
-		for (var entry : methodValueMap.entrySet()) {
-			metaMap.put(MethodMetadata.fromMethod(entry.getKey()), entry.getValue());
-		}
-		return new SerializableForm(metaMap, strict);
-	}
-
-	// TODO: figure out a way to also allow this to make use of KeyedAlikeMap (check if worth)
-	/*
-	This is harder than it seems at first. You have to have each of them reference *some* kind of common object, like
-	the KeyedAlikeMapFactory, but if the keys aren't serializable, then you can't use that. We have to figure out a way
-	to convert to and from the "safe" keys but only on a single centralized instance.
-	 */
-	private record SerializableForm(Map<MethodMetadata, Object> methodMetaMap, boolean strict) implements Serializable {
-		@Serial
-		private Object readResolve() {
-			Map<Method, Object> methodMap = new HashMap<>(methodMetaMap.size());
-			for (var entry : methodMetaMap.entrySet()) {
-				try {
-					methodMap.put(entry.getKey().toMethod(), entry.getValue());
-				}
-				catch (NoSuchMethodException | ClassNotFoundException e) {
-					throw new RuntimeException(e);
-				}
-			}
-			return new ObjectInvocationHandler(methodMap, strict);
-		}
-	}
-
-	// TODO: this should be de-duplicated with the equivalent in StructInvocationHandler, but that would break
-	// serialization compatibility, so hold off for now.
-	public static final class MethodMetadata implements Serializable {
-		@Serial
-		private static final long serialVersionUID = 1L;
-
-		private final String methodName;
-		private final String[] parameterTypeNames;
-		private final String interfaceClassName;
-
-		private MethodMetadata(String methodName, String[] parameterTypeNames, String interfaceClassName) {
-			this.methodName = methodName.intern();
-			for (int i = 0; i < parameterTypeNames.length; i++) {
-				parameterTypeNames[i] = parameterTypeNames[i].intern();
-			}
-			this.parameterTypeNames = parameterTypeNames;
-			this.interfaceClassName = interfaceClassName.intern();
-		}
-
-		public static MethodMetadata fromMethod(Method method) {
-			return new MethodMetadata(
-					method.getName(),
-					Arrays.stream(method.getParameterTypes()).map(Class::getName).toArray(String[]::new),
-					method.getDeclaringClass().getName()
-			);
-		}
-
-		public Method toMethod() throws NoSuchMethodException, ClassNotFoundException {
-			Class<?> interfaceClass = Class.forName(interfaceClassName);
-			Class<?>[] parameterTypes = Arrays.stream(parameterTypeNames)
-					.map(name -> {
-						try {
-							return Class.forName(name);
-						}
-						catch (ClassNotFoundException e) {
-							throw new RuntimeException(e);
-						}
-					}).toArray(Class<?>[]::new);
-			return interfaceClass.getMethod(methodName, parameterTypes);
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj) return true;
-			if (obj == null || getClass() != obj.getClass()) return false;
-			MethodMetadata that = (MethodMetadata) obj;
-			return methodName.equals(that.methodName) &&
-			       Arrays.equals(parameterTypeNames, that.parameterTypeNames) &&
-			       interfaceClassName.equals(that.interfaceClassName);
-		}
-
-		@Override
-		public int hashCode() {
-			int result = Objects.hash(methodName, interfaceClassName);
-			result = 31 * result + Arrays.hashCode(parameterTypeNames);
-			return result;
-		}
-	}
 }

--- a/src/main/java/gg/xp/xivapi/mappers/objects/StructFieldMapper.java
+++ b/src/main/java/gg/xp/xivapi/mappers/objects/StructFieldMapper.java
@@ -3,9 +3,11 @@ package gg.xp.xivapi.mappers.objects;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gg.xp.xivapi.clienttypes.XivApiBase;
-import gg.xp.xivapi.collections.KeyedAlikeMapFactory;
-import gg.xp.xivapi.exceptions.XivApiException;
 import gg.xp.xivapi.clienttypes.XivApiStruct;
+import gg.xp.xivapi.collections.KeySerDe;
+import gg.xp.xivapi.collections.KeyedAlikeMapFactory;
+import gg.xp.xivapi.mappers.objects.serialization.MethodKeySerDe;
+import gg.xp.xivapi.exceptions.XivApiException;
 import gg.xp.xivapi.impl.XivApiContext;
 import gg.xp.xivapi.mappers.FieldMapper;
 import gg.xp.xivapi.mappers.QueryFieldsBuilder;
@@ -18,7 +20,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -62,7 +63,8 @@ public class StructFieldMapper<X> implements FieldMapper<X> {
 		Set<Method> allMethods = new HashSet<>(methodFieldMap.keySet());
 		allMethods.add(svMethod);
 		allMethods.add(tsMethod);
-		this.kaMapFactory = new KeyedAlikeMapFactory<>(allMethods);
+		KeySerDe<Method, ?> serDe = new MethodKeySerDe();
+		this.kaMapFactory = new KeyedAlikeMapFactory<>(allMethods, serDe);
 	}
 
 	@Override

--- a/src/main/java/gg/xp/xivapi/mappers/objects/StructInvocationHandler.java
+++ b/src/main/java/gg/xp/xivapi/mappers/objects/StructInvocationHandler.java
@@ -9,28 +9,21 @@ import gg.xp.xivapi.mappers.util.MappingUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ObjectStreamException;
 import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 public class StructInvocationHandler implements InvocationHandler, Serializable {
 
 	private static final Logger log = LoggerFactory.getLogger(StructInvocationHandler.class);
 
-	@Serial
-	private static final long serialVersionUID = -7240936731264081326L;
-
 	private static final Method equalsMethod;
 	private static final Method hashCodeMethod;
 	private static final Method mapMethod;
+
 	static {
 		try {
 			equalsMethod = Object.class.getMethod("equals", Object.class);
@@ -42,9 +35,12 @@ public class StructInvocationHandler implements InvocationHandler, Serializable 
 		}
 	}
 
+	@Serial
+	private static final long serialVersionUID = 2L;
 	private final Map<Method, Object> methodValueMap;
 	private final boolean strict;
 
+	@SuppressWarnings("AssignmentOrReturnOfFieldWithMutableType") // We don't want a copy for memory reasons
 	public StructInvocationHandler(Map<Method, Object> methodValueMap, boolean strict) {
 		this.methodValueMap = methodValueMap;
 		this.strict = strict;
@@ -117,89 +113,6 @@ public class StructInvocationHandler implements InvocationHandler, Serializable 
 		}
 
 		return value;
-	}
-
-
-
-	@Serial
-	private Object writeReplace() throws ObjectStreamException {
-		Map<MethodMetadata, Object> metaMap = new HashMap<>(methodValueMap.size());
-		for (var entry : methodValueMap.entrySet()) {
-			metaMap.put(MethodMetadata.fromMethod(entry.getKey()), entry.getValue());
-		}
-		return new SerializableForm(metaMap, strict);
-	}
-
-	private record SerializableForm(Map<MethodMetadata, Object> methodMetaMap, boolean strict) implements Serializable {
-		private Object readResolve() {
-			Map<Method, Object> methodMap = new HashMap<>(methodMetaMap.size());
-			for (var entry : methodMetaMap.entrySet()) {
-				try {
-					methodMap.put(entry.getKey().toMethod(), entry.getValue());
-				}
-				catch (NoSuchMethodException | ClassNotFoundException e) {
-					throw new RuntimeException(e);
-				}
-			}
-			return new StructInvocationHandler(methodMap, strict);
-		}
-	}
-
-	public static final class MethodMetadata implements Serializable {
-		@Serial
-		private static final long serialVersionUID = 1L;
-
-		private final String methodName;
-		private final String[] parameterTypeNames;
-		private final String interfaceClassName;
-
-		private MethodMetadata(String methodName, String[] parameterTypeNames, String interfaceClassName) {
-			this.methodName = methodName.intern();
-			for (int i = 0; i < parameterTypeNames.length; i++) {
-				parameterTypeNames[i] = parameterTypeNames[i].intern();
-			}
-			this.parameterTypeNames = parameterTypeNames;
-			this.interfaceClassName = interfaceClassName.intern();
-		}
-
-		public static MethodMetadata fromMethod(Method method) {
-			return new MethodMetadata(
-					method.getName(),
-					Arrays.stream(method.getParameterTypes()).map(Class::getName).toArray(String[]::new),
-					method.getDeclaringClass().getName()
-			);
-		}
-
-		public Method toMethod() throws NoSuchMethodException, ClassNotFoundException {
-			Class<?> interfaceClass = Class.forName(interfaceClassName);
-			Class<?>[] parameterTypes = Arrays.stream(parameterTypeNames)
-					.map(name -> {
-						try {
-							return Class.forName(name);
-						}
-						catch (ClassNotFoundException e) {
-							throw new RuntimeException(e);
-						}
-					}).toArray(Class<?>[]::new);
-			return interfaceClass.getMethod(methodName, parameterTypes);
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj) return true;
-			if (obj == null || getClass() != obj.getClass()) return false;
-			MethodMetadata that = (MethodMetadata) obj;
-			return methodName.equals(that.methodName) &&
-			       Arrays.equals(parameterTypeNames, that.parameterTypeNames) &&
-			       interfaceClassName.equals(that.interfaceClassName);
-		}
-
-		@Override
-		public int hashCode() {
-			int result = Objects.hash(methodName, interfaceClassName);
-			result = 31 * result + Arrays.hashCode(parameterTypeNames);
-			return result;
-		}
 	}
 
 }

--- a/src/main/java/gg/xp/xivapi/mappers/objects/serialization/MethodKeySerDe.java
+++ b/src/main/java/gg/xp/xivapi/mappers/objects/serialization/MethodKeySerDe.java
@@ -1,0 +1,26 @@
+package gg.xp.xivapi.mappers.objects.serialization;
+
+import gg.xp.xivapi.collections.KeySerDe;
+
+import java.io.Serial;
+import java.lang.reflect.Method;
+
+public class MethodKeySerDe implements KeySerDe<Method, MethodMetadata> {
+	@Serial
+	private static final long serialVersionUID = 2L;
+
+	@Override
+	public MethodMetadata toSerializableForm(Method key) {
+		return MethodMetadata.fromMethod(key);
+	}
+
+	@Override
+	public Method fromSerializeableForm(MethodMetadata serializable) {
+		try {
+			return serializable.toMethod();
+		}
+		catch (NoSuchMethodException | ClassNotFoundException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/src/main/java/gg/xp/xivapi/mappers/objects/serialization/MethodMetadata.java
+++ b/src/main/java/gg/xp/xivapi/mappers/objects/serialization/MethodMetadata.java
@@ -1,0 +1,62 @@
+package gg.xp.xivapi.mappers.objects.serialization;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Serializes Method objects by their name, parameter types, and declaring class.
+ */
+public final class MethodMetadata implements Serializable {
+	@Serial
+	private static final long serialVersionUID = 1L;
+
+	private final String methodName;
+	private final String[] parameterTypeNames;
+	private final String interfaceClassName;
+
+	private MethodMetadata(String methodName, String[] parameterTypeNames, String interfaceClassName) {
+		this.methodName = methodName.intern();
+		for (int i = 0; i < parameterTypeNames.length; i++) {
+			parameterTypeNames[i] = parameterTypeNames[i].intern();
+		}
+		this.parameterTypeNames = parameterTypeNames;
+		this.interfaceClassName = interfaceClassName.intern();
+	}
+
+	public static MethodMetadata fromMethod(Method method) {
+		return new MethodMetadata(
+				method.getName(),
+				Arrays.stream(method.getParameterTypes()).map(Class::getName).toArray(String[]::new),
+				method.getDeclaringClass().getName()
+		);
+	}
+
+	public Method toMethod() throws NoSuchMethodException, ClassNotFoundException {
+		Class<?> interfaceClass = Class.forName(interfaceClassName);
+		Class<?>[] parameterTypes = new Class<?>[parameterTypeNames.length];
+		for (int i = 0; i < parameterTypeNames.length; i++) {
+			parameterTypes[i] = Class.forName(parameterTypeNames[i]);
+		}
+		return interfaceClass.getMethod(methodName, parameterTypes);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) return true;
+		if (obj == null || getClass() != obj.getClass()) return false;
+		MethodMetadata that = (MethodMetadata) obj;
+		return methodName.equals(that.methodName) &&
+		       Arrays.equals(parameterTypeNames, that.parameterTypeNames) &&
+		       interfaceClassName.equals(that.interfaceClassName);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = Objects.hash(methodName, interfaceClassName);
+		result = 31 * result + Arrays.hashCode(parameterTypeNames);
+		return result;
+	}
+}

--- a/src/test/groovy/gg/xp/xivapi/test/collections/MapSerializationProxyTest.groovy
+++ b/src/test/groovy/gg/xp/xivapi/test/collections/MapSerializationProxyTest.groovy
@@ -1,0 +1,100 @@
+package gg.xp.xivapi.test.collections
+
+import gg.xp.xivapi.collections.KeySerDe
+import gg.xp.xivapi.collections.KeyedAlikeMapFactory
+import gg.xp.xivapi.collections.MapSerializationProxy
+import groovy.transform.CompileStatic
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@CompileStatic
+class MapSerializationProxyTest {
+
+	static class NonSerializableKey {
+		String id
+
+		NonSerializableKey(String id) { this.id = id }
+
+		@Override
+		boolean equals(Object o) { o instanceof NonSerializableKey && ((NonSerializableKey) o).id == id }
+
+		@Override
+		int hashCode() { id.hashCode() }
+	}
+
+	static class KeySerDeImpl implements KeySerDe<NonSerializableKey, String>, Serializable {
+		@Serial
+		static final long serialVersionUID = 1L
+
+		@Override
+		String toSerializableForm(NonSerializableKey key) { key.id }
+
+		@Override
+		NonSerializableKey fromSerializeableForm(String serializable) { new NonSerializableKey(serializable) }
+	}
+
+	@Test
+	void testSerialization() {
+		Map<NonSerializableKey, String> underlying = new HashMap<>()
+		NonSerializableKey k1 = new NonSerializableKey("k1")
+		NonSerializableKey k2 = new NonSerializableKey("k2")
+		underlying.put(k1, "v1")
+		underlying.put(k2, "v2")
+
+		KeySerDe<NonSerializableKey, String> serDe = new KeySerDeImpl()
+		MapSerializationProxy<NonSerializableKey, String> proxy = new MapSerializationProxy<>(underlying, serDe)
+
+		// Verify it works as a map
+		Assertions.assertEquals(2, proxy.size())
+		Assertions.assertEquals("v1", proxy.get(k1))
+		Assertions.assertEquals("v2", proxy.get(k2))
+
+		// Serialize
+		ByteArrayOutputStream baos = new ByteArrayOutputStream()
+		ObjectOutputStream oos = new ObjectOutputStream(baos)
+		oos.writeObject(proxy)
+		oos.close()
+
+		// Deserialize
+		ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray())
+		ObjectInputStream ois = new ObjectInputStream(bais)
+		MapSerializationProxy<NonSerializableKey, String> deserialized = (MapSerializationProxy<NonSerializableKey, String>) ois.readObject()
+
+		// Verify deserialized proxy
+		Assertions.assertEquals(2, deserialized.size())
+		// Note: they are new objects because of deserialization
+		Assertions.assertEquals("v1", deserialized.get(new NonSerializableKey("k1")))
+		Assertions.assertEquals("v2", deserialized.get(new NonSerializableKey("k2")))
+
+		Assertions.assertEquals(proxy, deserialized)
+	}
+
+	@Test
+	void testKeyedAlikeMapSerialization() {
+		NonSerializableKey k1 = new NonSerializableKey("k1")
+		NonSerializableKey k2 = new NonSerializableKey("k2")
+		Set<NonSerializableKey> keys = new LinkedHashSet<>([k1, k2])
+
+		KeySerDe<NonSerializableKey, String> serDe = new KeySerDeImpl()
+		KeyedAlikeMapFactory<NonSerializableKey> factory = new KeyedAlikeMapFactory<>(keys, serDe)
+
+		var map = factory.create()
+		map.put(k1, "value1")
+		map.put(k2, "value2")
+
+		// Serialize
+		ByteArrayOutputStream baos = new ByteArrayOutputStream()
+		ObjectOutputStream oos = new ObjectOutputStream(baos)
+		oos.writeObject(map)
+		oos.close()
+
+		// Deserialize
+		ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray())
+		ObjectInputStream ois = new ObjectInputStream(bais)
+		var deserializedMap = ois.readObject() as Map<NonSerializableKey, String>
+
+		Assertions.assertEquals("value1", deserializedMap.get(k1))
+		Assertions.assertEquals("value2", deserializedMap.get(k2))
+		Assertions.assertEquals(map, deserializedMap)
+	}
+}

--- a/src/test/groovy/gg/xp/xivapi/test/collections/SharedKeyMapSerializationTest.groovy
+++ b/src/test/groovy/gg/xp/xivapi/test/collections/SharedKeyMapSerializationTest.groovy
@@ -1,0 +1,75 @@
+package gg.xp.xivapi.test.collections
+
+import gg.xp.xivapi.collections.KeyedAlikeMap
+import gg.xp.xivapi.collections.KeyedAlikeMapFactory
+import gg.xp.xivapi.mappers.objects.serialization.MethodKeySerDe
+import gg.xp.xivapi.mappers.objects.ObjectInvocationHandler
+import gg.xp.xivapi.test.testutils.TestUtils
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+
+class SharedKeyMapSerializationTest {
+
+	interface TestInterface {
+		String getName()
+		int getId()
+	}
+
+	@Test
+	void testSharedMapAfterSerialization() {
+		Method getNameMethod = TestInterface.class.getMethod("getName")
+		Method getIdMethod = TestInterface.class.getMethod("getId")
+		Set<Method> methods = [getNameMethod, getIdMethod] as Set
+		
+		var serDe = new MethodKeySerDe()
+		var factory = new KeyedAlikeMapFactory<Method>(methods, serDe)
+		
+		var map1 = factory.create()
+		map1.put(getNameMethod, "Item 1")
+		map1.put(getIdMethod, 1)
+		
+		var map2 = factory.create()
+		map2.put(getNameMethod, "Item 2")
+		map2.put(getIdMethod, 2)
+		
+		// Both maps should share the same keyMapping
+		// We can't access it directly but we can verify it by looking at internal structure or just trusting the factory
+		// For verification, let's put them in a list and serialize the list
+		
+		def handler1 = new ObjectInvocationHandler(map1, true)
+		def proxy1 = Proxy.newProxyInstance(this.class.classLoader, [TestInterface] as Class[], handler1) as TestInterface
+		
+		def handler2 = new ObjectInvocationHandler(map2, true)
+		def proxy2 = Proxy.newProxyInstance(this.class.classLoader, [TestInterface] as Class[], handler2) as TestInterface
+		
+		def list = [proxy1, proxy2]
+		
+		def deserializedList = TestUtils.serializeAndDeserialize(list) as List<TestInterface>
+		
+		def dProxy1 = deserializedList[0]
+		def dProxy2 = deserializedList[1]
+		
+		Assertions.assertEquals("Item 1", dProxy1.getName())
+		Assertions.assertEquals(1, dProxy1.getId())
+		Assertions.assertEquals("Item 2", dProxy2.getName())
+		Assertions.assertEquals(2, dProxy2.getId())
+		
+		// Now verify that they share the same backing keyMapping
+		def dHandler1 = Proxy.getInvocationHandler(dProxy1) as ObjectInvocationHandler
+		def dHandler2 = Proxy.getInvocationHandler(dProxy2) as ObjectInvocationHandler
+		
+		def dMap1 = dHandler1.methodValueMap as KeyedAlikeMap
+		def dMap2 = dHandler2.methodValueMap as KeyedAlikeMap
+		
+		// Accessing private field keyMapping via reflection
+		def field = KeyedAlikeMap.class.getDeclaredField("keyMapping")
+		field.setAccessible(true)
+		
+		def keyMapping1 = field.get(dMap1)
+		def keyMapping2 = field.get(dMap2)
+		
+		Assertions.assertSame(keyMapping1, keyMapping2, "Key mappings should be the same reference after deserialization")
+	}
+}

--- a/src/test/groovy/gg/xp/xivapi/test/pagertest/BasicListTest.groovy
+++ b/src/test/groovy/gg/xp/xivapi/test/pagertest/BasicListTest.groovy
@@ -3,6 +3,7 @@ package gg.xp.xivapi.test.pagertest
 import gg.xp.xivapi.XivApiClient
 import gg.xp.xivapi.clienttypes.XivApiSettings
 import gg.xp.xivapi.pagination.ListOptions
+import gg.xp.xivapi.test.testutils.TestUtils
 import groovy.transform.CompileStatic
 import org.apache.commons.collections4.IteratorUtils
 import org.junit.jupiter.api.Assertions
@@ -57,6 +58,38 @@ class BasicListTest {
 
 		Assertions.assertEquals(124, dumped[124].rowId)
 		Assertions.assertEquals("Being Mortal", dumped[124].action.name)
+
+		// Size before: 153916
+		// Size after: 85026
+		List<AozAction> deserialized = (List<AozAction>) TestUtils.serializeAndDeserialize(dumped)
+
+		verifySameKeyMapping(dumped)
+		verifySameKeyMapping(deserialized)
+	}
+
+	private static void verifySameKeyMapping(List<AozAction> list) {
+		var first = list[0]
+		var firstMap = getBackingMap(first)
+		var firstKeyMapping = getKeyMapping(firstMap)
+
+		list.eachWithIndex { AozAction item, int index ->
+			var map = getBackingMap(item)
+			var keyMapping = getKeyMapping(map)
+			Assertions.assertSame(firstKeyMapping, keyMapping, "Item at index $index does not share the same key mapping")
+		}
+	}
+
+	private static Map getBackingMap(Object proxy) {
+		var handler = java.lang.reflect.Proxy.getInvocationHandler(proxy)
+		var field = handler.getClass().getDeclaredField("methodValueMap")
+		field.setAccessible(true)
+		return (Map) field.get(handler)
+	}
+
+	private static Object getKeyMapping(Map map) {
+		var field = map.getClass().getDeclaredField("keyMapping")
+		field.setAccessible(true)
+		return field.get(map)
 	}
 
 	@Test

--- a/src/test/groovy/gg/xp/xivapi/test/testutils/TestUtils.groovy
+++ b/src/test/groovy/gg/xp/xivapi/test/testutils/TestUtils.groovy
@@ -20,7 +20,7 @@ class TestUtils {
 
 			// Deserialize the object from the byte array input stream
 			def deserializedObj = ois.readObject()
-			log.info "Object serialized and deserialized successfully"
+			log.info "Object serialized and deserialized successfully. Serialized size: {} bytes", serializedData.length
 			return deserializedObj as X
 		}
 	}


### PR DESCRIPTION
This makes it so that KeyedAlikeMaps with non-serializable keys can use a serialization proxy to allow for proper serialization. This means that instances that shared the same key mapping before serialization will share the same mapping after deserialization (assuming they came from the same object stream).